### PR TITLE
Add comment to clarify that ChaCha20-Poly1305 cipher uses no padding …

### DIFF
--- a/src/main/java/org/saidone/service/BcCryptoServiceImpl.java
+++ b/src/main/java/org/saidone/service/BcCryptoServiceImpl.java
@@ -74,6 +74,7 @@ public class BcCryptoServiceImpl extends AbstractCryptoService implements Crypto
     private int saltLength;
     @Min(12)
     private int nonceLength;
+    // ChaCha20-Poly1305 is a stream cipher with AEAD; no padding is required or used.
     private static final String CIPHER_TRANSFORMATION = "ChaCha20-Poly1305";
     private static final String KEY_ALGORITHM = "ChaCha20";
 


### PR DESCRIPTION
…because it is a stream cipher with AEAD