### PR TITLE
Fix cleanup timing for recently processed nodes

### DIFF
--- a/src/main/java/org/saidone/filter/RecentlyProcessedFilter.java
+++ b/src/main/java/org/saidone/filter/RecentlyProcessedFilter.java
@@ -91,7 +91,7 @@ public class RecentlyProcessedFilter extends AbstractEventFilter {
 
     @Scheduled(fixedDelay = 5 * 60 * 1000)
     public void cleanRecentlyProcessedNodes() {
-        recentlyProcessedNodes.entrySet().stream().filter(e -> (e.getValue() + threshold) < System.currentTimeMillis())
+        recentlyProcessedNodes.entrySet().stream().filter(e -> e.getValue() < System.currentTimeMillis())
                 .forEach(e -> {
                     log.debug("Removing node {} from recentlyProcessedNodes", e.getKey());
                     recentlyProcessedNodes.remove(e.getKey());


### PR DESCRIPTION
## Summary
- correct expiry check in `RecentlyProcessedFilter`

## Testing
- `mvnw -q test` *(fails: `.mvn/wrapper/maven-wrapper.properties: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68420270aab8832fb46d114da727a7fd