### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Global configuration is stored in `application.yml` file, the relevant parameter
 | ARCHIVING_JOB_QUERY           | TYPE:'cm:content' AND ASPECT:'anv:archive' | Query for selecting documents to be archived                        |
 | VAULT_HASH_ALGORITHM          | SHA-256                                    | Hash stored as metadata on GridFS                                   |
 | VAULT_DOUBLE_CHECK            | true                                       | Double check content integrity before removing document on Alfresco |
-| VAULT_ENCRYPTION_ENABLED      | true                                       | Enable content encrypyion                                           |
+| VAULT_ENCRYPTION_ENABLED      | true                                       | Enable content encryption                                           |
 | VAULT_ENCRYPT_METADATA        | true                                       | Encrypt also metadata                                               |
 | VAULT_ENCRYPTION_SECRET       | changeme                                   | Encryption secret                                                   |
 


### PR DESCRIPTION
## Summary
- fix typo in README: encrypyion -> encryption

## Testing
- `mvn test -Dlicense.skip=true` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684203e9dc8c832f9237fb6311f87a67