### PR TITLE
Fix test order conflict

### DIFF
--- a/src/test/java/org/saidone/test/VaultApiControllerTests.java
+++ b/src/test/java/org/saidone/test/VaultApiControllerTests.java
@@ -103,7 +103,7 @@ class VaultApiControllerTests extends BaseTest {
     }
 
     @Test
-    @Order(10)
+    @Order(20)
     @SneakyThrows
     void getNodeContentTest() {
         val nodeId = createNode().getId();


### PR DESCRIPTION
## Summary
- ensure unique @Order values for API tests so they run deterministically

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684207701ec8832fab22c8a83c922866