### PR TITLE
Implement auditing filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Global configuration is stored in `application.yml` file, the relevant parameter
 | VAULT_ENCRYPTION_ENABLED      | true                                       | Enable content encryption                                           |
 | VAULT_ENCRYPT_METADATA        | true                                       | Encrypt also metadata                                               |
 | VAULT_ENCRYPTION_SECRET       | changeme                                   | Encryption secret                                                   |
+| AUDIT_ENABLED                 | false                                      | Enable web request auditing                                         |
 
 ## Build
 

--- a/src/main/java/org/saidone/audit/AuditEntry.java
+++ b/src/main/java/org/saidone/audit/AuditEntry.java
@@ -1,0 +1,18 @@
+package org.saidone.audit;
+
+import lombok.Data;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+import java.util.Map;
+
+@Data
+@Document(collection = "vault_audit")
+public class AuditEntry {
+    @Id
+    private String id;
+    private Instant timestamp;
+    private Map<String, Object> metadata;
+    private String type;
+}

--- a/src/main/java/org/saidone/audit/AuditService.java
+++ b/src/main/java/org/saidone/audit/AuditService.java
@@ -1,0 +1,24 @@
+package org.saidone.audit;
+
+import lombok.RequiredArgsConstructor;
+import org.saidone.component.BaseComponent;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AuditService extends BaseComponent {
+
+    private final MongoTemplate mongoTemplate;
+
+    public void saveEntry(Map<String, Object> metadata, String type) {
+        AuditEntry entry = new AuditEntry();
+        entry.setTimestamp(Instant.now());
+        entry.setMetadata(metadata);
+        entry.setType(type);
+        mongoTemplate.insert(entry);
+    }
+}

--- a/src/main/java/org/saidone/audit/AuditWebFilter.java
+++ b/src/main/java/org/saidone/audit/AuditWebFilter.java
@@ -1,0 +1,44 @@
+package org.saidone.audit;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@ConditionalOnProperty(name = "application.audit.enabled", havingValue = "true")
+@RequiredArgsConstructor
+@Slf4j
+public class AuditWebFilter implements WebFilter {
+
+    private final AuditService auditService;
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        val request = exchange.getRequest();
+        Map<String, Object> metadata = new HashMap<>();
+        if (request.getRemoteAddress() != null) {
+            metadata.put("ip", request.getRemoteAddress().getAddress().getHostAddress());
+        }
+        metadata.put("userAgent", request.getHeaders().getFirst("User-Agent"));
+        metadata.put("path", request.getPath().value());
+        metadata.put("method", request.getMethodValue());
+        auditService.saveEntry(metadata, "request");
+        return chain.filter(exchange).doFinally(signal -> {
+            Map<String, Object> responseData = new HashMap<>();
+            responseData.put("status", exchange.getResponse().getStatusCode() != null ?
+                    exchange.getResponse().getStatusCode().value() : null);
+            responseData.put("path", request.getPath().value());
+            auditService.saveEntry(responseData, "response");
+        });
+    }
+}
+


### PR DESCRIPTION
## Summary
- add AuditEntry document and AuditService
- implement AuditWebFilter to log requests/responses
- document `AUDIT_ENABLED` environment variable

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845323068d8832fbd1bbeb4a61adb2e