### PR TITLE
Add audit log API endpoint

### DIFF
--- a/src/main/java/org/saidone/controller/AuditApiController.java
+++ b/src/main/java/org/saidone/controller/AuditApiController.java
@@ -1,0 +1,80 @@
+package org.saidone.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import lombok.SneakyThrows;
+import org.apache.logging.log4j.util.Strings;
+import org.saidone.audit.AuditEntry;
+import org.saidone.audit.AuditService;
+import org.saidone.service.AlfrescoService;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.nio.charset.Charset;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/audit")
+@RequiredArgsConstructor
+@Tag(name = "Audit API", description = "Audit log operations")
+public class AuditApiController {
+
+    private final AuditService auditService;
+    private final AlfrescoService alfrescoService;
+
+    private boolean isAuthorized(String authHeader) {
+        if (Strings.isBlank(authHeader)) return false;
+        val userIdAndPassword = new String(Base64.getDecoder().decode(authHeader.split("\\s")[1]), Charset.defaultCharset()).split(":");
+        return alfrescoService.isAdmin(userIdAndPassword[0], userIdAndPassword[1]);
+    }
+
+    @SecurityRequirement(name = "basicAuth")
+    @GetMapping
+    @Operation(
+            summary = "Get audit entries",
+            description = "Retrieves audit log entries with optional filtering.",
+            parameters = {
+                    @Parameter(name = "type", description = "Entry type", in = ParameterIn.QUERY),
+                    @Parameter(name = "from", description = "Start timestamp (ISO-8601)", in = ParameterIn.QUERY),
+                    @Parameter(name = "to", description = "End timestamp (ISO-8601)", in = ParameterIn.QUERY),
+                    @Parameter(name = "page", description = "Page number", in = ParameterIn.QUERY),
+                    @Parameter(name = "size", description = "Page size", in = ParameterIn.QUERY)
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Entries retrieved", content = @Content(mediaType = "application/json", schema = @Schema(implementation = AuditEntry.class))),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content),
+                    @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content)
+            })
+    @SneakyThrows
+    public ResponseEntity<List<AuditEntry>> getEntries(
+            @Parameter(hidden = true) @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String auth,
+            @RequestParam(required = false) String type,
+            @RequestParam(required = false) Instant from,
+            @RequestParam(required = false) Instant to,
+            @RequestParam(required = false, defaultValue = "0") int page,
+            @RequestParam(required = false, defaultValue = "20") int size) {
+
+        if (!isAuthorized(auth)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "timestamp"));
+        val list = auditService.findEntries(type, from, to, pageable);
+        return ResponseEntity.ok(list);
+    }
+}

--- a/src/test/java/org/saidone/test/AuditApiControllerTests.java
+++ b/src/test/java/org/saidone/test/AuditApiControllerTests.java
@@ -1,0 +1,62 @@
+package org.saidone.test;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.saidone.audit.AuditEntry;
+import org.saidone.audit.AuditService;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Slf4j
+class AuditApiControllerTests extends BaseTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+    @Autowired
+    private AuditService auditService;
+
+    @Value("${content.service.security.basicAuth.username}")
+    private String userName;
+    @Value("${content.service.security.basicAuth.password}")
+    private String password;
+    private static String basicAuth;
+
+    @BeforeEach
+    public void beforeEach(org.junit.jupiter.api.TestInfo testInfo) {
+        super.before(testInfo);
+        if (basicAuth == null) {
+            basicAuth = String.format("Basic %s", Base64.getEncoder().encodeToString((userName + ":" + password).getBytes(StandardCharsets.UTF_8)));
+        }
+        log.info("Running --> {}", testInfo.getDisplayName());
+    }
+
+    @Test
+    @SneakyThrows
+    void getAuditEntries() {
+        auditService.saveEntry(new HashMap<>(), "test");
+        auditService.saveEntry(new HashMap<>(), "test");
+
+        webTestClient.get().uri(uriBuilder -> uriBuilder.path("/api/audit")
+                        .queryParam("type", "test")
+                        .build())
+                .header(HttpHeaders.AUTHORIZATION, basicAuth)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(AuditEntry.class)
+                .value(list -> assertTrue(list.size() >= 2));
+    }
+}


### PR DESCRIPTION
## Summary
- expose audit log retrieval via `/api/audit`
- query logs with filters and pagination
- test retrieving audit entries

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847c9e8d390832f98e53e44e3879f13