### PR TITLE
Add javadoc and dep-check workflows

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,0 +1,26 @@
+name: OWASP Dependency Check
+on:
+  schedule:
+    - cron: '15 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  dependency-check:
+    runs-on: ubuntu-latest
+    name: Dependency Check
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+          cache: 'maven'
+      - uses: GovTechSG/dependency-check-action@v1.0.0
+        with:
+          Project-Name: ${{ github.repository }}
+      - name: Upload Depcheck report
+        uses: actions/upload-artifact@v3
+        with:
+          name: dependency-check-report
+          path: ${{ github.workspace }}/reports

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -1,0 +1,26 @@
+name: Publish Javadoc
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+          cache: 'maven'
+      - name: Configure Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+      - name: Publish Javadoc
+        run: |
+          chmod +x ./publish-javadoc.sh
+          ./publish-javadoc.sh


### PR DESCRIPTION
## Summary
- add workflow to publish Javadoc with existing script
- add workflow to run OWASP dependency check

## Testing
- `mvn -q -DskipTests -Dlicense.skip=true clean package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ccec6908832f81052cf6af9f4274