### PR TITLE
Fix Basic Auth parsing

### DIFF
--- a/src/main/java/org/saidone/controller/AuditApiController.java
+++ b/src/main/java/org/saidone/controller/AuditApiController.java
@@ -37,9 +37,23 @@ public class AuditApiController {
     private final AlfrescoService alfrescoService;
 
     private boolean isAuthorized(String authHeader) {
-        if (Strings.isBlank(authHeader)) return false;
-        val userIdAndPassword = new String(Base64.getDecoder().decode(authHeader.split("\\s")[1]), Charset.defaultCharset()).split(":");
-        return alfrescoService.isAdmin(userIdAndPassword[0], userIdAndPassword[1]);
+        if (Strings.isBlank(authHeader)) {
+            return false;
+        }
+        val parts = authHeader.trim().split("\\s+", 2);
+        if (parts.length != 2 || !"basic".equalsIgnoreCase(parts[0])) {
+            return false;
+        }
+        try {
+            val decoded = new String(Base64.getDecoder().decode(parts[1]), Charset.defaultCharset());
+            val userIdAndPassword = decoded.split(":", 2);
+            if (userIdAndPassword.length != 2) {
+                return false;
+            }
+            return alfrescoService.isAdmin(userIdAndPassword[0], userIdAndPassword[1]);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
     @SecurityRequirement(name = "basicAuth")


### PR DESCRIPTION
## Summary
- handle Basic auth parsing edge cases to improve validation

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684bc00a82a4832fbcdae9283d5a2957