### PR TITLE
Add Javadoc to exception classes

### DIFF
--- a/src/main/java/org/saidone/exception/ApiExceptionError.java
+++ b/src/main/java/org/saidone/exception/ApiExceptionError.java
@@ -21,6 +21,13 @@ package org.saidone.exception;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import lombok.Data;
 
+/**
+ * Represents an error payload returned by the REST API.
+ * <p>
+ * This class mirrors the structure used by Alfresco to describe errors
+ * occurring while processing a request. It can be serialized and returned as
+ * part of the response body.
+ */
 @Data
 @JsonRootName(value = "error")
 public class ApiExceptionError {

--- a/src/main/java/org/saidone/exception/HashesMismatchException.java
+++ b/src/main/java/org/saidone/exception/HashesMismatchException.java
@@ -18,6 +18,10 @@
 
 package org.saidone.exception;
 
+/**
+ * Exception thrown when a node's checksum stored in Alfresco does not match the
+ * value stored in the vault.
+ */
 public class HashesMismatchException extends VaultException {
     public HashesMismatchException(String alfrescoHash, String mongoHash) {
         super("""

--- a/src/main/java/org/saidone/exception/NodeNotOnAlfrescoException.java
+++ b/src/main/java/org/saidone/exception/NodeNotOnAlfrescoException.java
@@ -18,6 +18,9 @@
 
 package org.saidone.exception;
 
+/**
+ * Signals that a requested node cannot be found in the Alfresco repository.
+ */
 public class NodeNotOnAlfrescoException extends VaultException {
     public NodeNotOnAlfrescoException(String message) {
         super(String.format("Node %s not found on the vault", message));

--- a/src/main/java/org/saidone/exception/NodeNotOnVaultException.java
+++ b/src/main/java/org/saidone/exception/NodeNotOnVaultException.java
@@ -18,6 +18,9 @@
 
 package org.saidone.exception;
 
+/**
+ * Thrown when a node cannot be located in the vault storage.
+ */
 public class NodeNotOnVaultException extends VaultException {
     public NodeNotOnVaultException(String message) {
         super(String.format("Node %s not found on the vault", message));

--- a/src/main/java/org/saidone/exception/VaultException.java
+++ b/src/main/java/org/saidone/exception/VaultException.java
@@ -18,6 +18,9 @@
 
 package org.saidone.exception;
 
+/**
+ * Base class for all runtime exceptions thrown by the Alfresco Node Vault.
+ */
 public class VaultException extends RuntimeException {
     public VaultException(String message) {
         super(message);


### PR DESCRIPTION
## Summary
- document exception classes under `org.saidone.exception`

## Testing
- `mvn test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685647563ffc832fb85f14f4523bfa85