### PR TITLE
Add Javadoc for NodeNotFoundException

### DIFF
--- a/src/main/java/org/saidone/exception/NodeNotFoundException.java
+++ b/src/main/java/org/saidone/exception/NodeNotFoundException.java
@@ -18,6 +18,12 @@
 
 package org.saidone.exception;
 
+/**
+ * Generic exception thrown when a requested node cannot be located.
+ * <p>
+ * More specific subclasses clarify whether the node was expected to be
+ * present in Alfresco or in the vault storage.
+ */
 public class NodeNotFoundException extends VaultException {
     public NodeNotFoundException(String message) {
         super(message);


### PR DESCRIPTION
## Summary
- document `NodeNotFoundException` in `org.saidone.exception`

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685664148274832f8494d871af8860f3