### PR TITLE
Add Javadoc for progress tracking streams

### DIFF
--- a/src/main/java/org/saidone/misc/ProgressTrackingInputStream.java
+++ b/src/main/java/org/saidone/misc/ProgressTrackingInputStream.java
@@ -24,6 +24,13 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+/**
+ * {@link InputStream} wrapper that logs read progress for debugging purposes.
+ * <p>
+ * The wrapper counts the number of bytes read from the underlying stream and
+ * logs the progress in 10% increments when trace logging is enabled.
+ * </p>
+ */
 @Slf4j
 public class ProgressTrackingInputStream extends FilterInputStream {
 
@@ -32,12 +39,25 @@ public class ProgressTrackingInputStream extends FilterInputStream {
     private long bytesRead = 0;
     private int lastLoggedPercentage = 0;
 
+    /**
+     * Creates a new progress tracking stream.
+     *
+     * @param in            the wrapped input stream
+     * @param nodeId        identifier of the node being read
+     * @param contentLength total expected length of the stream in bytes
+     */
     public ProgressTrackingInputStream(InputStream in, String nodeId, long contentLength) {
         super(in);
         this.nodeId = nodeId;
         this.contentLength = contentLength;
     }
 
+    /**
+     * Reads a single byte from the stream and updates the progress.
+     *
+     * @return the byte read or {@code -1} if the end of the stream is reached
+     * @throws IOException if an I/O error occurs
+     */
     @Override
     public int read() throws IOException {
         int b = in.read();
@@ -48,6 +68,15 @@ public class ProgressTrackingInputStream extends FilterInputStream {
         return b;
     }
 
+    /**
+     * Reads bytes into an array and updates the read progress.
+     *
+     * @param b   the buffer into which the data is read
+     * @param off the start offset in the destination array
+     * @param len the maximum number of bytes to read
+     * @return the number of bytes read or {@code -1} if the end of the stream is reached
+     * @throws IOException if an I/O error occurs
+     */
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
         int bytes = in.read(b, off, len);
@@ -58,6 +87,9 @@ public class ProgressTrackingInputStream extends FilterInputStream {
         return bytes;
     }
 
+    /**
+     * Logs the progress of bytes read if the next threshold has been reached.
+     */
     private void logProgress() {
         if (contentLength > 0) {
             int percentage = (int) ((double) bytesRead / contentLength * 100);

--- a/src/main/java/org/saidone/misc/ProgressTrackingOutputStream.java
+++ b/src/main/java/org/saidone/misc/ProgressTrackingOutputStream.java
@@ -24,6 +24,13 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
+/**
+ * {@link OutputStream} wrapper that logs upload progress for debugging purposes.
+ * <p>
+ * Bytes written to the underlying stream are counted and progress is logged in
+ * 10% increments when trace logging is enabled.
+ * </p>
+ */
 @Slf4j
 public class ProgressTrackingOutputStream extends FilterOutputStream {
 
@@ -32,12 +39,25 @@ public class ProgressTrackingOutputStream extends FilterOutputStream {
     private long bytesWritten = 0;
     private int lastLoggedPercentage = 0;
 
+    /**
+     * Creates a new progress tracking output stream.
+     *
+     * @param out           the underlying output stream
+     * @param nodeId        identifier of the node being written
+     * @param contentLength total expected length of the stream in bytes
+     */
     public ProgressTrackingOutputStream(OutputStream out, String nodeId, long contentLength) {
         super(out);
         this.nodeId = nodeId;
         this.contentLength = contentLength;
     }
 
+    /**
+     * Writes a single byte and updates the write progress.
+     *
+     * @param b the byte to be written
+     * @throws IOException if an I/O error occurs
+     */
     @Override
     public void write(int b) throws IOException {
         out.write(b);
@@ -45,6 +65,14 @@ public class ProgressTrackingOutputStream extends FilterOutputStream {
         if (log.isTraceEnabled()) logProgress();
     }
 
+    /**
+     * Writes bytes from a buffer and updates the write progress.
+     *
+     * @param b   the data
+     * @param off the start offset in the data
+     * @param len the number of bytes to write
+     * @throws IOException if an I/O error occurs
+     */
     @Override
     public void write(byte[] b, int off, int len) throws IOException {
         out.write(b, off, len);
@@ -52,6 +80,9 @@ public class ProgressTrackingOutputStream extends FilterOutputStream {
         if (log.isTraceEnabled()) logProgress();
     }
 
+    /**
+     * Logs the progress of bytes written if the next threshold has been reached.
+     */
     private void logProgress() {
         if (contentLength > 0) {
             int percentage = (int) ((double) bytesWritten / contentLength * 100);


### PR DESCRIPTION
## Summary
- document ProgressTrackingInputStream and ProgressTrackingOutputStream

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68579f8a700c832f98cb7341b1290e4e