### PR TITLE
Improve error handling in Vault API

### DIFF
--- a/src/main/java/org/saidone/controller/VaultApiController.java
+++ b/src/main/java/org/saidone/controller/VaultApiController.java
@@ -58,7 +58,7 @@ public class VaultApiController {
         log.error(e.getMessage());
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(e.getMessage());
+                .body("Internal server error");
     }
 
     @ExceptionHandler(VaultException.class)
@@ -67,7 +67,7 @@ public class VaultApiController {
         log.error(e.getMessage());
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(e.getMessage());
+                .body("Internal server error");
     }
 
     @ExceptionHandler(NodeNotFoundException.class)
@@ -76,7 +76,7 @@ public class VaultApiController {
         log.error(e.getMessage());
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
-                .body(e.getMessage());
+                .body("Node not found");
     }
 
     @ExceptionHandler(OutOfMemoryError.class)

--- a/src/test/java/org/saidone/test/VaultApiControllerTests.java
+++ b/src/test/java/org/saidone/test/VaultApiControllerTests.java
@@ -96,7 +96,10 @@ class VaultApiControllerTests extends BaseTest {
     void getNodeTest() {
         val nodeId = createNode().getId();
         performRequestAndProcess(HttpMethod.GET, "/api/vault/nodes/{nodeId}", new Object[]{nodeId},
-                null, 404, String.class, body -> assertTrue(body.contains(nodeId)));
+                null, 404, String.class, body -> {
+                    assertEquals("Node not found", body);
+                    assertFalse(body.contains(nodeId));
+                });
         vaultService.archiveNode(nodeId);
         performRequestAndProcess(HttpMethod.GET, "/api/vault/nodes/{nodeId}", new Object[]{nodeId},
                 null, 200, String.class, body -> assertTrue(body.contains(nodeId)));
@@ -108,7 +111,10 @@ class VaultApiControllerTests extends BaseTest {
     void getNodeContentTest() {
         val nodeId = createNode().getId();
         performRequestAndProcess(HttpMethod.GET, "/api/vault/nodes/{nodeId}/content", new Object[]{nodeId},
-                null, 404, String.class, body -> assertTrue(body.contains(nodeId)));
+                null, 404, String.class, body -> {
+                    assertEquals("Node not found", body);
+                    assertFalse(body.contains(nodeId));
+                });
         vaultService.archiveNode(nodeId);
         performRequestAndProcess(HttpMethod.GET, "/api/vault/nodes/{nodeId}/content", new Object[]{nodeId},
                 null, 200, byte[].class, body -> assertTrue(body.length > 0));
@@ -120,7 +126,10 @@ class VaultApiControllerTests extends BaseTest {
     void restoreNodeTest() {
         val nodeId = createNode().getId();
         performRequestAndProcess(HttpMethod.POST, "/api/vault/nodes/{nodeId}/restore", new Object[]{nodeId},
-                Strings.EMPTY, 404, String.class, body -> assertTrue(body.contains(nodeId)));
+                Strings.EMPTY, 404, String.class, body -> {
+                    assertEquals("Node not found", body);
+                    assertFalse(body.contains(nodeId));
+                });
         vaultService.archiveNode(nodeId);
         val result = new AtomicReference<String>();
         val consumer = (Consumer<String>) body -> {
@@ -142,7 +151,10 @@ class VaultApiControllerTests extends BaseTest {
         performRequestAndProcess(HttpMethod.POST, "/api/vault/nodes/{nodeId}/archive", new Object[]{nodeId},
                 Strings.EMPTY, 200, String.class, body -> assertTrue(body.contains(nodeId)));
         performRequestAndProcess(HttpMethod.POST, "/api/vault/nodes/{nodeId}/archive", new Object[]{nodeId},
-                Strings.EMPTY, 404, String.class, body -> assertTrue(body.contains(nodeId)));
+                Strings.EMPTY, 404, String.class, body -> {
+                    assertEquals("Node not found", body);
+                    assertFalse(body.contains(nodeId));
+                });
         assertThrows(FeignException.NotFound.class, () -> alfrescoService.getNode(nodeId));
     }
 


### PR DESCRIPTION
## Summary
- hide exception messages in HTTP responses
- keep error logging
- adjust tests for generic error messages

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6857c51d1588832f8e688897a38b2951