### PR TITLE
Add javadoc to vault services and controller

### DIFF
--- a/src/main/java/org/saidone/controller/VaultApiController.java
+++ b/src/main/java/org/saidone/controller/VaultApiController.java
@@ -43,6 +43,13 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * REST controller that exposes operations for interacting with the vault.
+ * <p>
+ * All endpoints require basic authentication and delegate the heavy lifting to
+ * {@link org.saidone.service.VaultService} and {@link org.saidone.service.ContentService}.
+ * </p>
+ */
 @RestController
 @RequestMapping("/api/vault")
 @RequiredArgsConstructor
@@ -54,6 +61,12 @@ public class VaultApiController {
     private final ContentService contentService;
     private final AuthenticationService authenticationService;
 
+    /**
+     * Handles any unexpected exception thrown during request processing.
+     *
+     * @param e the exception that was raised
+     * @return a generic {@code 500 Internal Server Error} response
+     */
     @ExceptionHandler(Exception.class)
     @Operation(hidden = true)
     public ResponseEntity<String> handleException(Exception e) {
@@ -63,6 +76,12 @@ public class VaultApiController {
                 .body("Internal server error");
     }
 
+    /**
+     * Handles vault specific errors that may occur while processing a request.
+     *
+     * @param e the thrown {@link VaultException}
+     * @return a generic error response with HTTP status {@code 500}
+     */
     @ExceptionHandler(VaultException.class)
     @Operation(hidden = true)
     public ResponseEntity<String> handleVaultException(Exception e) {
@@ -72,6 +91,12 @@ public class VaultApiController {
                 .body("Internal server error");
     }
 
+    /**
+     * Handles cases where the requested node cannot be found in the vault.
+     *
+     * @param e the thrown exception
+     * @return a response with HTTP status {@code 404 Not Found}
+     */
     @ExceptionHandler(NodeNotFoundException.class)
     @Operation(hidden = true)
     public ResponseEntity<String> handleNodeNotFoundException(NodeNotFoundException e) {
@@ -81,6 +106,12 @@ public class VaultApiController {
                 .body("Node not found");
     }
 
+    /**
+     * Handles out-of-memory situations that may occur when streaming large files.
+     *
+     * @param e the {@link OutOfMemoryError} encountered
+     * @return a response indicating that the server ran out of memory
+     */
     @ExceptionHandler(OutOfMemoryError.class)
     @Operation(hidden = true)
     public ResponseEntity<String> handleOutOfMemoryError(OutOfMemoryError e) {
@@ -108,6 +139,13 @@ public class VaultApiController {
                             content = @Content)
             })
     @SneakyThrows
+    /**
+     * Returns the metadata of a node stored in the vault.
+     *
+     * @param auth   optional Basic authentication header
+     * @param nodeId identifier of the node to retrieve
+     * @return the node metadata wrapped in an {@link Entry} object
+     */
     public ResponseEntity<?> getNode(
             @Parameter(hidden = true) @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String auth,
             @PathVariable String nodeId) {
@@ -138,6 +176,14 @@ public class VaultApiController {
                     @ApiResponse(responseCode = "500", description = "Internal server error",
                             content = @Content)
             })
+    /**
+     * Streams the binary content of a node.
+     *
+     * @param auth       optional Basic authentication header
+     * @param nodeId     identifier of the node
+     * @param attachment {@code true} if the content should be sent as a download attachment
+     * @return the streamed content wrapped as an {@link InputStreamResource}
+     */
     public ResponseEntity<InputStreamResource> getNodeContent(
             @Parameter(hidden = true) @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String auth,
             @PathVariable String nodeId,
@@ -180,6 +226,14 @@ public class VaultApiController {
                             content = @Content)
             })
     @SneakyThrows
+    /**
+     * Restores a node previously archived in the vault.
+     *
+     * @param auth               optional Basic authentication header
+     * @param nodeId             identifier of the node to restore
+     * @param restorePermissions {@code true} to also restore permissions
+     * @return a textual confirmation message
+     */
     public ResponseEntity<?> restoreNode(
             @Parameter(hidden = true) @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String auth,
             @PathVariable String nodeId,
@@ -209,6 +263,13 @@ public class VaultApiController {
                     @ApiResponse(responseCode = "500", description = "Internal server error",
                             content = @Content)
             })
+    /**
+     * Archives an Alfresco node and removes it from the repository.
+     *
+     * @param auth   optional Basic authentication header
+     * @param nodeId identifier of the node to archive
+     * @return a confirmation message
+     */
     public ResponseEntity<?> archiveNode(
             @Parameter(hidden = true) @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String auth,
             @PathVariable String nodeId) {

--- a/src/main/java/org/saidone/service/ContentService.java
+++ b/src/main/java/org/saidone/service/ContentService.java
@@ -23,14 +23,43 @@ import org.saidone.model.NodeContent;
 
 import java.io.InputStream;
 
+/**
+ * Abstraction over the persistence mechanism used to store node content.
+ * Implementations handle saving, retrieving and deleting binary files as well
+ * as computing cryptographic hashes.
+ */
 public interface ContentService {
 
+    /**
+     * Saves the content of the provided node into the underlying store.
+     *
+     * @param node        node whose content should be archived
+     * @param inputStream stream providing the node content
+     */
     void archiveNodeContent(Node node, InputStream inputStream);
 
+    /**
+     * Retrieves previously archived content for the given node id.
+     *
+     * @param nodeId identifier of the node
+     * @return a {@link NodeContent} descriptor containing stream and metadata
+     */
     NodeContent getNodeContent(String nodeId);
 
+    /**
+     * Deletes content associated with the given node id from the store.
+     *
+     * @param nodeId identifier of the node
+     */
     void deleteFileById(String nodeId);
 
+    /**
+     * Computes the cryptographic hash of a stored node's content using the given algorithm.
+     *
+     * @param nodeId    identifier of the node
+     * @param algorithm name of the hash algorithm, e.g. MD5 or SHA-256
+     * @return the hexadecimal encoded hash string
+     */
     String computeHash(String nodeId, String algorithm);
 
 }

--- a/src/main/java/org/saidone/service/GridFsContentService.java
+++ b/src/main/java/org/saidone/service/GridFsContentService.java
@@ -34,6 +34,14 @@ import org.springframework.stereotype.Service;
 import java.io.InputStream;
 import java.util.HashMap;
 
+/**
+ * {@link ContentService} implementation backed by MongoDB GridFS.
+ * <p>
+ * This class handles persisting node content streams as GridFS files and
+ * retrieving them on demand. Checksums are calculated during the archive
+ * operation and stored as metadata.
+ * </p>
+ */
 @RequiredArgsConstructor
 @Service
 @Slf4j
@@ -98,11 +106,23 @@ public class GridFsContentService implements ContentService {
         return nodeContent;
     }
 
+    /**
+     * Removes the stored content associated with the given node identifier.
+     *
+     * @param nodeId the id of the node whose content should be deleted
+     */
     @Override
     public void deleteFileById(String nodeId) {
         gridFsRepository.deleteFileById(nodeId);
     }
 
+    /**
+     * Computes the checksum of a node's content stored in GridFS using the provided algorithm.
+     *
+     * @param nodeId    identifier of the node
+     * @param algorithm name of the hash algorithm
+     * @return the resulting hash string
+     */
     @Override
     public String computeHash(String nodeId, String algorithm) {
         return gridFsRepository.computeHash(nodeId, algorithm);


### PR DESCRIPTION
## Summary
- document VaultApiController and its endpoints
- add interface and method level javadoc for `ContentService`
- document GridFsContentService and its helper methods

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685d4df6001c832fb67f57790cead7a3