### PR TITLE
Improve javadoc

### DIFF
--- a/src/main/java/org/saidone/misc/AnvDigestInputStream.java
+++ b/src/main/java/org/saidone/misc/AnvDigestInputStream.java
@@ -26,29 +26,43 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
 
 /**
- * AnvDigestInputStream is a specialized {@link FilterInputStream} that computes a cryptographic digest
- * of the data as it is read from the underlying {@link InputStream}.
+ * {@code AnvDigestInputStream} wraps another {@link InputStream} and computes a
+ * message digest while the data is read.
  * <p>
- * The digest is updated incrementally with each read operation using the specified algorithm (such as "SHA-256" or "MD5").
- * Once the stream has been fully read, the computed digest value can be retrieved as a hexadecimal string via {@link #getHash()}.
- * <p>
- * Typical use cases include automatic hash calculation (checksum or fingerprint) for content verification
- * during streaming or processing of large files without needing to load all data into memory.
+ * The digest algorithm is provided at construction time and each read operation
+ * updates the underlying {@link MessageDigest}. When the stream has been
+ * consumed the final hash value can be obtained via {@link #getHash()}.
+ * This utility is typically used when a checksum or fingerprint of the streamed
+ * content is required without buffering the entire input in memory.
  */
 public class AnvDigestInputStream extends FilterInputStream {
 
     private final MessageDigest digest;
 
+    /**
+     * Creates a new digesting stream using the supplied algorithm.
+     *
+     * @param inputStream the underlying stream to read
+     * @param algorithm   name of the {@link MessageDigest} algorithm
+     * @throws NoSuchAlgorithmException if the algorithm is not available
+     */
     public AnvDigestInputStream(InputStream inputStream, String algorithm) throws NoSuchAlgorithmException {
         super(inputStream);
         this.digest = MessageDigest.getInstance(algorithm);
     }
 
+    /**
+     * Creates a digesting stream that performs no hashing.  This constructor is
+     * mainly useful when the same type is required but hashing is disabled.
+     *
+     * @param inputStream the underlying stream
+     */
     public AnvDigestInputStream(InputStream inputStream) throws NoSuchAlgorithmException {
         super(inputStream);
         digest = null;
     }
 
+    /** {@inheritDoc} */
     @Override
     public int read() throws IOException {
         int byteRead = in.read();
@@ -58,6 +72,7 @@ public class AnvDigestInputStream extends FilterInputStream {
         return byteRead;
     }
 
+    /** {@inheritDoc} */
     @Override
     public int read(byte[] b) throws IOException {
         int bytesRead = in.read(b);
@@ -67,6 +82,7 @@ public class AnvDigestInputStream extends FilterInputStream {
         return bytesRead;
     }
 
+    /** {@inheritDoc} */
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
         int bytesRead = in.read(b, off, len);
@@ -76,6 +92,12 @@ public class AnvDigestInputStream extends FilterInputStream {
         return bytesRead;
     }
 
+    /**
+     * Returns the computed hash as a lowercase hexadecimal string. This method
+     * should be called once the stream has been fully consumed.
+     *
+     * @return the digest of the read bytes
+     */
     public String getHash() {
         return HexFormat.of().formatHex(digest.digest());
     }

--- a/src/main/java/org/saidone/repository/EncryptedGridFsRepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/EncryptedGridFsRepositoryImpl.java
@@ -36,9 +36,10 @@ import java.io.OutputStream;
 import java.util.Map;
 
 /**
- * Repository implementation for storing and retrieving files in GridFS with encryption support.
- * This implementation encrypts files before saving and decrypts them when reading,
- * based on the encryption enabled property.
+ * GridFS repository that transparently encrypts content before it is persisted
+ * and decrypts it when retrieved. The behaviour is enabled only when the
+ * {@code application.service.vault.encryption.enabled} property is set to
+ * {@code true}.
  */
 @Repository
 @ConditionalOnProperty(name = "application.service.vault.encryption.enabled", havingValue = "true")

--- a/src/main/java/org/saidone/service/crypto/AbstractCryptoService.java
+++ b/src/main/java/org/saidone/service/crypto/AbstractCryptoService.java
@@ -31,10 +31,10 @@ import java.util.Arrays;
 import java.util.Base64;
 
 /**
- * Abstract base class implementing cryptographic operations using different key derivation functions
- * Extends BaseComponent for lifecycle management and implements CryptoService interface
- * Supports PBKDF2, HKDF and Argon2 key derivation functions
- * Contains inner configuration classes for each KDF type with validation constraints
+ * Base implementation for {@link CryptoService} that provides common
+ * functionality for the concrete encryption services. It offers helper methods
+ * to derive secret keys using PBKDF2, HKDF or Argon2 and defines configuration
+ * beans for the supported key derivation algorithms.
  */
 @Setter
 public abstract class AbstractCryptoService extends BaseComponent implements CryptoService {

--- a/src/main/java/org/saidone/service/crypto/BcCryptoServiceImpl.java
+++ b/src/main/java/org/saidone/service/crypto/BcCryptoServiceImpl.java
@@ -40,24 +40,11 @@ import java.security.SecureRandom;
 import java.security.Security;
 
 /**
- * Implements symmetric encryption/decryption using ChaCha20-Poly1305 via the Bouncy Castle provider.
- * <p>
- * Key features:
- * - ChaCha20 encryption with Poly1305 authentication
- * - Configurable salt and nonce lengths
- * - Support for PBKDF2, HKDF and Argon2 key derivation
- * - Stream-based operation for efficient memory usage
- * - Base64 text encoding/decoding support
- * <p>
- * Configuration:
- * - Prefix: application.service.vault.encryption.bc
- * - Enabled when encryption.enabled=true and encryption.impl=bc
- * <p>
- * Security measures:
- * - Per-operation random salt and nonce generation
- * - Password-based key derivation with strong KDFs
- * - Authenticated encryption with Poly1305 mode
- * - Efficient processing of large data streams
+ * Cryptographic service based on the Bouncy Castle provider that performs
+ * ChaCha20-Poly1305 encryption. The bean is activated when
+ * {@code application.service.vault.encryption.impl} is set to {@code bc}.
+ * Random salt and nonce values are generated for every operation and the
+ * encryption key is derived using the configured KDF implementation.
  */
 @Service
 @Setter

--- a/src/main/java/org/saidone/service/crypto/CryptoService.java
+++ b/src/main/java/org/saidone/service/crypto/CryptoService.java
@@ -23,12 +23,10 @@ import org.saidone.misc.AnvDigestInputStream;
 import java.io.InputStream;
 
 /**
- * Abstraction for symmetric encryption and decryption services.
- * <p>
- * Implementations such as {@link JcaCryptoServiceImpl} and
- * {@link BcCryptoServiceImpl} perform stream based encryption using
- * authenticated cipher modes. Returned {@link InputStream} instances must be
- * consumed and closed by the caller.
+ * Abstraction for stream based symmetric encryption and decryption services.
+ * Implementations return {@link InputStream} instances that must be consumed
+ * and closed by the caller. Concrete implementations include
+ * {@link JcaCryptoServiceImpl} and {@link BcCryptoServiceImpl}.
  */
 public interface CryptoService {
 

--- a/src/main/java/org/saidone/service/crypto/JcaCryptoServiceImpl.java
+++ b/src/main/java/org/saidone/service/crypto/JcaCryptoServiceImpl.java
@@ -38,24 +38,11 @@ import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 
 /**
- * Implements symmetric encryption/decryption using AES-GCM mode via Java Cryptography Architecture (JCA).
- * <p>
- * Key features:
- * - AES encryption in GCM authenticated mode
- * - Configurable salt and IV lengths
- * - Support for PBKDF2, HKDF and Argon2 key derivation
- * - Stream-based operation for efficient memory usage
- * - Base64 text encoding/decoding support
- * <p>
- * Configuration:
- * - Prefix: application.service.vault.encryption.jca
- * - Enabled when encryption.enabled=true and encryption.impl=jca
- * <p>
- * Security measures:
- * - Per-operation random salt and IV generation
- * - Password-based key derivation with strong KDFs
- * - Authenticated encryption with GCM mode
- * - No padding for precise size control
+ * {@link CryptoService} implementation based on the JCA provider. It encrypts
+ * and decrypts data using AES in GCM mode. The bean is active when
+ * {@code application.service.vault.encryption.impl} is set to {@code jca}.
+ * Random salt and IV values are produced for every operation and the secret key
+ * is derived using the configured KDF implementation.
  */
 @Service
 @Setter


### PR DESCRIPTION
## Summary
- rewrite javadocs for `AnvDigestInputStream`
- update javadocs for encrypted repository
- tidy up abstract crypto service docs
- simplify docs for BC and JCA crypto implementations
- refine crypto service interface docs

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68622ca49584832f9b6f7bbae137b23f