### PR TITLE
Fix javadoc for AnvDigestInputStream

### DIFF
--- a/src/main/java/org/saidone/misc/AnvDigestInputStream.java
+++ b/src/main/java/org/saidone/misc/AnvDigestInputStream.java
@@ -52,10 +52,11 @@ public class AnvDigestInputStream extends FilterInputStream {
     }
 
     /**
-     * Creates a digesting stream that performs no hashing.  This constructor is
+     * Creates a digesting stream that performs no hashing. This constructor is
      * mainly useful when the same type is required but hashing is disabled.
      *
      * @param inputStream the underlying stream
+     * @throws NoSuchAlgorithmException if the algorithm is not available
      */
     public AnvDigestInputStream(InputStream inputStream) throws NoSuchAlgorithmException {
         super(inputStream);
@@ -94,9 +95,11 @@ public class AnvDigestInputStream extends FilterInputStream {
 
     /**
      * Returns the computed hash as a lowercase hexadecimal string. This method
-     * should be called once the stream has been fully consumed.
+     * should be called once the stream has been fully consumed. If hashing was
+     * disabled via {@link #AnvDigestInputStream(InputStream)}, this method
+     * returns {@code null}.
      *
-     * @return the digest of the read bytes
+     * @return the digest of the read bytes or {@code null} if hashing is disabled
      */
     public String getHash() {
         return digest != null ? HexFormat.of().formatHex(digest.digest()) : null;


### PR DESCRIPTION
## Summary
- update javadoc for the no-hash constructor
- document possible `null` return from `getHash`

## Testing
- `javadoc -d /tmp/doc src/main/java/org/saidone/misc/AnvDigestInputStream.java`
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6862312f98a8832fa5c386a85b893332