### PR TITLE
Fix S3 upload configuration

### DIFF
--- a/src/main/java/org/saidone/repository/S3RepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/S3RepositoryImpl.java
@@ -24,7 +24,6 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.saidone.model.MetadataKeys;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -43,9 +42,12 @@ public class S3RepositoryImpl implements S3Repository {
 
     @Override
     public void putObject(InputStream inputStream, String bucketName, String nodeId) {
+        val clientConfig = s3Client.serviceClientConfiguration();
         @Cleanup val transferManager = S3TransferManager.builder()
                 .s3Client(S3AsyncClient.builder()
-                        .region(Region.EU_CENTRAL_1)
+                        .region(clientConfig.region())
+                        .endpointOverride(clientConfig.endpointOverride())
+                        .credentialsProvider(clientConfig.credentialsProvider())
                         .build())
                 .build();
         try {


### PR DESCRIPTION
## Summary
- use service client configuration when creating `S3AsyncClient`

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6864d7797ce0832fadd3e2765941dfa0