### PR TITLE
Fix javadoc in S3 repository classes

### DIFF
--- a/src/main/java/org/saidone/repository/EncryptedS3RepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/EncryptedS3RepositoryImpl.java
@@ -54,6 +54,11 @@ public class EncryptedS3RepositoryImpl extends S3RepositoryImpl {
 
     /**
      * Encrypts the provided stream before delegating to the parent implementation.
+     *
+     * @param bucketName  destination bucket
+     * @param node        node whose id acts as the key
+     * @param metadata    metadata key/value pairs to associate with the object
+     * @param inputStream content stream to encrypt and upload
      */
     @Override
     public void putObject(String bucketName, Node node, Map<String, String> metadata, InputStream inputStream) {
@@ -63,6 +68,10 @@ public class EncryptedS3RepositoryImpl extends S3RepositoryImpl {
 
     /**
      * Retrieves and decrypts the object content for the given node id.
+     *
+     * @param bucketName bucket containing the object
+     * @param nodeId     the node id / object key
+     * @return decrypted content stream
      */
     @Override
     public InputStream getObject(String bucketName, String nodeId) {

--- a/src/main/java/org/saidone/repository/S3Repository.java
+++ b/src/main/java/org/saidone/repository/S3Repository.java
@@ -33,9 +33,10 @@ public interface S3Repository {
      * Uploads a node's content to the specified S3 bucket using the node id as
      * object key.
      *
-     * @param inputStream the stream providing the content to store
      * @param bucketName  name of the target S3 bucket
      * @param node        node whose identifier will be used as the object key
+     * @param metadata    metadata key/value pairs to associate with the object
+     * @param inputStream the stream providing the content to store
      */
     void putObject(String bucketName, Node node, Map<String, String> metadata, InputStream inputStream);
 

--- a/src/main/java/org/saidone/repository/S3RepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/S3RepositoryImpl.java
@@ -53,9 +53,10 @@ public class S3RepositoryImpl implements S3Repository {
      * Uploads the provided stream as an object to S3. The node id is used as
      * the object key.
      *
-     * @param inputStream stream of the content to store
      * @param bucketName  destination bucket
      * @param node        node whose id acts as the key
+     * @param metadata    metadata key/value pairs to associate with the object
+     * @param inputStream stream of the content to store
      */
     @Override
     public void putObject(String bucketName, Node node, Map<String, String> metadata, InputStream inputStream) {


### PR DESCRIPTION
## Summary
- update parameter documentation in `S3Repository`
- align javadoc in `S3RepositoryImpl`
- add missing parameter docs in `EncryptedS3RepositoryImpl`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68651ab59678832fa2ffbba3040546d9