### PR TITLE
Fix and polish S3 repository javadocs

### DIFF
--- a/src/main/java/org/saidone/repository/EncryptedS3RepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/EncryptedS3RepositoryImpl.java
@@ -55,7 +55,9 @@ public class EncryptedS3RepositoryImpl extends S3RepositoryImpl {
     }
 
     /**
-     * Encrypts the provided stream before delegating to the parent implementation.
+     * Encrypts the provided content stream and stores it in S3. The object's
+     * metadata is updated to mark it as encrypted before delegating to the
+     * parent implementation.
      *
      * @param bucketName  destination bucket
      * @param node        node whose id acts as the key
@@ -69,7 +71,8 @@ public class EncryptedS3RepositoryImpl extends S3RepositoryImpl {
     }
 
     /**
-     * Retrieves and decrypts the object content for the given node id.
+     * Retrieves the encrypted object content from S3 and returns a decrypted
+     * stream using the configured {@link CryptoService}.
      *
      * @param bucketName bucket containing the object
      * @param nodeId     the node id / object key

--- a/src/main/java/org/saidone/repository/S3RepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/S3RepositoryImpl.java
@@ -72,13 +72,12 @@ public class S3RepositoryImpl implements S3Repository {
     }
 
     /**
-     * Retrieves the object content for the given node id. This default
-     * implementation returns {@code null} as it is expected to be overridden by
-     * concrete subclasses.
+     * Retrieves the object content for the given node id using the underlying
+     * {@link S3Client}.
      *
      * @param bucketName bucket containing the object
      * @param nodeId     the node id / object key
-     * @return the object content stream or {@code null}
+     * @return the object content stream
      */
     @Override
     public InputStream getObject(String bucketName, String nodeId) {
@@ -87,6 +86,14 @@ public class S3RepositoryImpl implements S3Repository {
                 .bucket(bucketName).key(nodeId).build());
     }
 
+    /**
+     * Checks whether the object stored for the given node id is marked as
+     * encrypted in its metadata.
+     *
+     * @param bucketName bucket containing the object
+     * @param nodeId     the object key / node id
+     * @return {@code true} if the object is encrypted, {@code false} otherwise
+     */
     private boolean isEncrypted(String bucketName, String nodeId) {
         val headObjectRequest = HeadObjectRequest.builder()
                 .bucket(bucketName)


### PR DESCRIPTION
## Summary
- fix outdated Javadoc comment in `S3RepositoryImpl#getObject`
- document helper method used to detect encryption status
- polish Javadoc in `EncryptedS3RepositoryImpl` to clarify behaviour

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653e8d3650832f9d933e6442263568