### PR TITLE
Fix NodeNotFoundOnAlfrescoException message

### DIFF
--- a/src/main/java/org/saidone/exception/NodeNotFoundOnAlfrescoException.java
+++ b/src/main/java/org/saidone/exception/NodeNotFoundOnAlfrescoException.java
@@ -23,6 +23,6 @@ package org.saidone.exception;
  */
 public class NodeNotFoundOnAlfrescoException extends NodeNotFoundException {
     public NodeNotFoundOnAlfrescoException(String message) {
-        super(String.format("Node %s not found on the vault", message));
+        super(String.format("Node %s not found on Alfresco", message));
     }
 }


### PR DESCRIPTION
## Summary
- correct typo in `NodeNotFoundOnAlfrescoException` constructor message

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68654c100fa0832fad2f5010209bf17d