### PR TITLE
Fix AuthenticationService charset

### DIFF
--- a/src/main/java/org/saidone/service/AuthenticationService.java
+++ b/src/main/java/org/saidone/service/AuthenticationService.java
@@ -23,7 +23,7 @@ import lombok.val;
 import org.apache.logging.log4j.util.Strings;
 import org.springframework.stereotype.Service;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 @RequiredArgsConstructor
@@ -41,7 +41,7 @@ public class AuthenticationService {
             return false;
         }
         try {
-            val decoded = new String(Base64.getDecoder().decode(parts[1]), Charset.defaultCharset());
+            val decoded = new String(Base64.getDecoder().decode(parts[1]), StandardCharsets.UTF_8);
             val userIdAndPassword = decoded.split(":", 2);
             if (userIdAndPassword.length != 2) {
                 return false;


### PR DESCRIPTION
## Summary
- use UTF-8 when decoding Basic auth header

## Testing
- `mvn -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68654c1b6534832fb4300a1bc0470108