### PR TITLE
Fix javadocs for repository activation conditions

### DIFF
--- a/src/main/java/org/saidone/repository/EncryptedGridFsRepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/EncryptedGridFsRepositoryImpl.java
@@ -36,9 +36,9 @@ import java.util.Map;
 
 /**
  * GridFS repository that transparently encrypts content before it is persisted
- * and decrypts it when retrieved. The behaviour is enabled only when the
- * {@code application.service.vault.encryption.enabled} property is set to
- * {@code true}.
+ * and decrypts it when retrieved. The bean is loaded only when
+ * {@code application.service.vault.encryption.enabled} is {@code true} and
+ * {@code application.service.vault.storage.impl} equals {@code "gridfs"}.
  */
 @Repository
 @ConditionalOnExpression(

--- a/src/main/java/org/saidone/repository/EncryptedMongoNodeRepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/EncryptedMongoNodeRepositoryImpl.java
@@ -30,8 +30,10 @@ import java.util.Optional;
 
 /**
  * Repository implementation that encrypts node data before saving to MongoDB
- * and decrypts it when retrieving. This implementation is active only when
- * vault encryption and metadata encryption are enabled in the application properties.
+ * and decrypts it when retrieving. The bean is activated only when both
+ * {@code application.service.vault.encryption.enabled} and
+ * {@code application.service.vault.encryption.metadata} are set to
+ * {@code true} in the application properties.
  */
 @Repository
 @ConditionalOnProperty(name = {"application.service.vault.encryption.enabled", "application.service.vault.encryption.metadata"},

--- a/src/main/java/org/saidone/repository/EncryptedS3RepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/EncryptedS3RepositoryImpl.java
@@ -35,6 +35,10 @@ import java.util.Map;
  * {@link S3RepositoryImpl} variant that transparently encrypts data before
  * uploading to S3 and decrypts it when retrieved. Encryption is delegated to
  * the provided {@link CryptoService}.
+ * <p>
+ * The bean becomes active only when
+ * {@code application.service.vault.encryption.enabled} is {@code true} and
+ * {@code application.service.vault.storage.impl} equals {@code "s3"}.
  */
 @Service
 @ConditionalOnExpression(

--- a/src/main/java/org/saidone/repository/GridFsRepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/GridFsRepositoryImpl.java
@@ -67,9 +67,10 @@ import java.util.Map;
  *   the hash algorithm selectable at runtime.</li>
  * </ul>
  * <p>
- * This implementation is registered in the Spring context only if the property
- * {@code application.service.vault.encryption.enabled} is set to {@code false}
- * or is not defined.
+ * This implementation is registered in the Spring context only when the
+ * property {@code application.service.vault.encryption.enabled} is set to
+ * {@code false} (or is missing) <strong>and</strong>
+ * {@code application.service.vault.storage.impl} equals {@code "gridfs"}.
  * <p>
  * Extends {@link org.saidone.component.BaseComponent} to inherit standardized
  * component lifecycle logging.

--- a/src/main/java/org/saidone/repository/S3RepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/S3RepositoryImpl.java
@@ -38,6 +38,10 @@ import java.util.Map;
  * Default {@link S3Repository} implementation relying on the AWS SDK
  * {@link S3Client}. The class exposes basic methods to upload and download
  * objects using a provided {@code S3Client} instance.
+ * <p>
+ * The bean is created only when {@code application.service.vault.encryption.enabled}
+ * is set to {@code false} and {@code application.service.vault.storage.impl}
+ * equals {@code "s3"}.
  */
 @Service
 @ConditionalOnExpression(


### PR DESCRIPTION
## Summary
- clarify when GridFS and S3 repository beans are loaded
- document activation conditions for encrypted repository implementations

## Testing
- `./mvnw -DskipITs test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6868c04dd720832fbef771d07e81c46c