### PR TITLE
Fix javadocs for crypto service activation

### DIFF
--- a/src/main/java/org/saidone/service/crypto/BcCryptoServiceImpl.java
+++ b/src/main/java/org/saidone/service/crypto/BcCryptoServiceImpl.java
@@ -40,8 +40,9 @@ import java.security.Security;
 
 /**
  * Cryptographic service based on the Bouncy Castle provider that performs
- * ChaCha20-Poly1305 encryption. The bean is activated when
- * {@code application.service.vault.encryption.impl} is set to {@code bc}.
+ * ChaCha20-Poly1305 encryption. The bean is activated when both
+ * {@code application.service.vault.encryption.enabled} is set to {@code true}
+ * and {@code application.service.vault.encryption.impl} is set to {@code bc}.
  * Random salt and nonce values are generated for every operation and the
  * encryption key is derived using the configured KDF implementation.
  */

--- a/src/main/java/org/saidone/service/crypto/JcaCryptoServiceImpl.java
+++ b/src/main/java/org/saidone/service/crypto/JcaCryptoServiceImpl.java
@@ -38,8 +38,9 @@ import java.security.SecureRandom;
 
 /**
  * {@link CryptoService} implementation based on the JCA provider. It encrypts
- * and decrypts data using AES in GCM mode. The bean is active when
- * {@code application.service.vault.encryption.impl} is set to {@code jca}.
+ * and decrypts data using AES in GCM mode. The bean is active when both
+ * {@code application.service.vault.encryption.enabled} is set to {@code true}
+ * and {@code application.service.vault.encryption.impl} is set to {@code jca}.
  * Random salt and IV values are produced for every operation and the secret key
  * is derived using the configured KDF implementation.
  */


### PR DESCRIPTION
## Summary
- update crypto service docs to reflect boolean condition in `@ConditionalOnExpression`

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6868c3bca548832f966a0eea67d24fbb