### PR TITLE
Fix build.bat to use anv output

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,11 +1,11 @@
 @echo off
 
-SET DIST_DIR=anp
+SET DIST_DIR=anv
 
 IF EXIST %DIST_DIR% RMDIR /S /Q %DIST_DIR%
 MKDIR %DIST_DIR%\log
 MKDIR %DIST_DIR%\config
 CALL mvn package -DskipTests -Dlicense.skip=true
-COPY target\anp.jar %DIST_DIR%
+COPY target\anv.jar %DIST_DIR%
 COPY src\main\resources\application.yml %DIST_DIR%\config
 COPY src\main\resources\example*.json %DIST_DIR%


### PR DESCRIPTION
## Summary
- update build.bat to use `anv` distribution name and jar

## Testing
- `wine cmd /c build.bat; ls -l anv`

------
https://chatgpt.com/codex/tasks/task_e_686c4491ea7c832fa6a6bb30c7b9def7