### PR TITLE
Add Ethereum notarization feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ and the indefinite retention of all documents in the active repository (unsustai
 - Scheduled or on-demand archiving
 - MongoDB storage for metadata and audit trail 
 - GridFS or S3 storage for binaries
+- Optional blockchain notarization of stored documents
 - Focus on [strong encryption](doc/Encryption.md) option for both content and metadata
 - Passwords securely stored in a secret engine
 - REST API with Alfresco proxy support
@@ -107,6 +108,11 @@ Global configuration is stored in `application.yml` file, the relevant parameter
 | VAULT_ENCRYPTION_SECRET_PATH  | AlfrescoNodeVault                          | Path of encryption secret in Vault secret engine                    |
 | VAULT_ENCRYPTION_SECRET_KEY   | anv.secret                                 | Key name of encryption secret                                       |
 | AUDIT_ENABLED                 | false                                      | Enable web request auditing                                         |
+| NOTARIZATION_JOB_ENABLED      | false                                      | Document notarization job switch                                    |
+| NOTARIZATION_JOB_CRON_EXPRESSION | 0 0/30 * * * ?                          | Cron expression for notarization job                                |
+| ETH_RPC_URL                   | http://localhost:8545                      | Ethereum RPC endpoint                                               |
+| ETH_PRIVATE_KEY               |                                           | Private key used to sign transactions                               |
+| ETH_ACCOUNT                   |                                           | Destination account for notarization transactions                   |
 
 ## Build
 

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,11 @@
             <version>2.31.77</version>
         </dependency>
         <dependency>
+            <groupId>org.web3j</groupId>
+            <artifactId>core</artifactId>
+            <version>5.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/src/main/java/org/saidone/config/EthereumConfig.java
+++ b/src/main/java/org/saidone/config/EthereumConfig.java
@@ -1,0 +1,14 @@
+package org.saidone.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "application.service.ethereum")
+@Data
+public class EthereumConfig {
+    private String rpcUrl;
+    private String privateKey;
+    private String account;
+}

--- a/src/main/java/org/saidone/job/DocumentNotarizationJob.java
+++ b/src/main/java/org/saidone/job/DocumentNotarizationJob.java
@@ -1,0 +1,46 @@
+package org.saidone.job;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.saidone.component.BaseComponent;
+import org.saidone.service.EthereumService;
+import org.saidone.service.NodeService;
+import org.saidone.service.content.ContentService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Periodically computes document hashes and stores them on the blockchain.
+ */
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "application.notarization-job.enabled", havingValue = "true")
+@EnableScheduling
+@Slf4j
+public class DocumentNotarizationJob extends BaseComponent {
+
+    private final NodeService nodeService;
+    private final ContentService contentService;
+    private final EthereumService ethereumService;
+
+    @Value("${application.service.vault.hash-algorithm}")
+    private String algorithm;
+
+    @Scheduled(cron = "${application.notarization-job.cron-expression}")
+    void notarize() {
+        doNotarize();
+    }
+
+    private synchronized void doNotarize() {
+        for (val node : nodeService.findByTxId(null)) {
+            val checksum = contentService.computeHash(node.getId(), algorithm);
+            val txId = ethereumService.storeHash(node.getId(), checksum);
+            node.setNotarizationTxId(txId);
+            nodeService.save(node);
+        }
+    }
+}

--- a/src/main/java/org/saidone/model/NodeWrapper.java
+++ b/src/main/java/org/saidone/model/NodeWrapper.java
@@ -57,6 +57,8 @@ public class NodeWrapper {
     private boolean encrypted;
     @Field("node")
     private String nodeJson;
+    @Field("ntx")
+    private String notarizationTxId;
 
     public NodeWrapper(Node node) throws IllegalArgumentException, JsonProcessingException {
         if (node == null) {

--- a/src/main/java/org/saidone/repository/MongoNodeRepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/MongoNodeRepositoryImpl.java
@@ -171,6 +171,18 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
         return mongoOperations.findAll(NodeWrapper.class);
     }
 
+    /**
+     * Retrieves node wrappers by notarization transaction ID. A {@code null} value
+     * matches nodes without a transaction ID.
+     *
+     * @param txId the transaction ID to filter by
+     * @return list of matching nodes
+     */
+    public List<NodeWrapper> findByTxId(String txId) {
+        val query = new Query(Criteria.where("ntx").is(txId));
+        return mongoOperations.find(query, NodeWrapper.class);
+    }
+
     @Override
     @NonNull
     public List<NodeWrapper> findAllById(@NonNull Iterable<String> ids) {

--- a/src/main/java/org/saidone/service/EthereumService.java
+++ b/src/main/java/org/saidone/service/EthereumService.java
@@ -1,0 +1,80 @@
+package org.saidone.service;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.saidone.component.BaseComponent;
+import org.saidone.config.EthereumConfig;
+import org.web3j.crypto.Credentials;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.http.HttpService;
+import org.web3j.protocol.core.methods.response.EthSendTransaction;
+import org.web3j.tx.RawTransactionManager;
+import org.web3j.tx.TransactionManager;
+import org.web3j.tx.gas.DefaultGasProvider;
+import org.web3j.utils.Numeric;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.math.BigInteger;
+
+/**
+ * Service responsible for interacting with an Ethereum node to store document hashes.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EthereumService extends BaseComponent {
+
+    private final EthereumConfig config;
+
+    private Web3j web3j;
+    private Credentials credentials;
+
+    @PostConstruct
+    @Override
+    public void init() {
+        super.init();
+        web3j = Web3j.build(new HttpService(config.getRpcUrl()));
+        if (config.getPrivateKey() != null && !config.getPrivateKey().isBlank()) {
+            credentials = Credentials.create(config.getPrivateKey());
+        }
+    }
+
+    @PreDestroy
+    @Override
+    public void stop() {
+        if (web3j != null) {
+            web3j.shutdown();
+        }
+        super.stop();
+    }
+
+    /**
+     * Sends a zero-value transaction containing the given hash as data.
+     *
+     * @param nodeId the node identifier
+     * @param hash   the hash to store on the blockchain
+     * @return the transaction hash
+     */
+    public String storeHash(String nodeId, String hash) {
+        try {
+            TransactionManager txManager = new RawTransactionManager(web3j, credentials);
+            String data = Numeric.toHexString(hash.getBytes(StandardCharsets.UTF_8));
+            EthSendTransaction tx = txManager.sendTransaction(
+                    DefaultGasProvider.GAS_PRICE,
+                    DefaultGasProvider.GAS_LIMIT,
+                    config.getAccount(),
+                    data,
+                    BigInteger.ZERO);
+            val txHash = tx.getTransactionHash();
+            log.debug("Notarized node {} with tx {}", nodeId, txHash);
+            return txHash;
+        } catch (Exception e) {
+            log.error("Error sending transaction for node {}: {}", nodeId, e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/org/saidone/service/MongoNodeService.java
+++ b/src/main/java/org/saidone/service/MongoNodeService.java
@@ -67,6 +67,16 @@ public class MongoNodeService extends BaseComponent implements NodeService {
         }
     }
 
+    @Override
+    public Iterable<NodeWrapper> findAll() {
+        return mongoNodeRepository.findAll();
+    }
+
+    @Override
+    public Iterable<NodeWrapper> findByTxId(String txId) {
+        return mongoNodeRepository.findByTxId(txId);
+    }
+
     /**
      * Deletes the node wrapper identified by the given ID.
      *
@@ -76,5 +86,4 @@ public class MongoNodeService extends BaseComponent implements NodeService {
     public void deleteById(String nodeId) {
         mongoNodeRepository.deleteById(nodeId);
     }
-
 }

--- a/src/main/java/org/saidone/service/NodeService.java
+++ b/src/main/java/org/saidone/service/NodeService.java
@@ -43,6 +43,23 @@ public interface NodeService {
     NodeWrapper findById(String nodeId);
 
     /**
+     * Retrieves all stored node wrappers.
+     *
+     * @return iterable collection of {@link NodeWrapper}
+     */
+    Iterable<NodeWrapper> findAll();
+
+    /**
+     * Retrieves all node wrappers having the given notarization transaction ID.
+     * A {@code null} transaction ID is used to select nodes that have not yet
+     * been notarized.
+     *
+     * @param txId the notarization transaction ID to filter by
+     * @return iterable collection of {@link NodeWrapper}
+     */
+    Iterable<NodeWrapper> findByTxId(String txId);
+
+    /**
      * Removes the stored node metadata identified by the given ID.
      *
      * @param nodeId the Alfresco node identifier

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,6 +88,9 @@ application:
     cron-expression: ${ARCHIVING_JOB_CRON_EXPRESSION:0 0/5 2-6 * * ?}
     query: ${ARCHIVING_JOB_QUERY:TYPE:'cm:content' AND ASPECT:'anv:archive'}
     enabled: ${ARCHIVING_JOB_ENABLED:true}
+  notarization-job:
+    cron-expression: ${NOTARIZATION_JOB_CRON_EXPRESSION:0 0/30 * * * ?}
+    enabled: ${NOTARIZATION_JOB_ENABLED:false}
   service:
     alfresco:
       include:
@@ -139,6 +142,9 @@ application:
           bucket: ${S3_BUCKET:anv}
           region: ${S3_REGION:eu-central-1}
           endpoint: ${S3_ENDPOINT:http://localhost:4566}
+    ethereum:
+      rpc-url: ${ETH_RPC_URL:http://localhost:8545}
+      private-key: ${ETH_PRIVATE_KEY:}
+      account: ${ETH_ACCOUNT:}
   same-node-processing-threshold: ${SAME_NODE_PROCESSING_THRESHOLD:10000}
-server:
-  port: 8086
+server:  port: 8086

--- a/src/test/java/org/saidone/test/DocumentNotarizationJobTests.java
+++ b/src/test/java/org/saidone/test/DocumentNotarizationJobTests.java
@@ -1,0 +1,38 @@
+package org.saidone.test;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.saidone.job.DocumentNotarizationJob;
+import org.saidone.model.NodeWrapper;
+import org.saidone.service.EthereumService;
+import org.saidone.service.NodeService;
+import org.saidone.service.content.ContentService;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+class DocumentNotarizationJobTests {
+
+    @Test
+    void notarizeCallsStoreHash() {
+        NodeService nodeService = mock(NodeService.class);
+        ContentService contentService = mock(ContentService.class);
+        EthereumService ethereumService = mock(EthereumService.class);
+
+        NodeWrapper node = new NodeWrapper();
+        node.setId("1");
+        when(nodeService.findByTxId(null)).thenReturn(List.of(node));
+        when(contentService.computeHash("1", "SHA-256")).thenReturn("abc");
+        when(ethereumService.storeHash("1", "abc")).thenReturn("txid");
+
+        DocumentNotarizationJob job = new DocumentNotarizationJob(nodeService, contentService, ethereumService);
+        ReflectionTestUtils.setField(job, "algorithm", "SHA-256");
+
+        job.notarize();
+
+        verify(ethereumService).storeHash("1", "abc");
+        verify(nodeService).save(argThat(n -> "txid".equals(n.getNotarizationTxId())));
+    }
+}


### PR DESCRIPTION
## Summary
- add Web3j dependency
- introduce Ethereum configuration and service
- implement document notarization job
- expose new NodeService method for fetching all nodes
- document Ethereum notarization feature and configuration
- add unit test for DocumentNotarizationJob
- store notarization transaction id and skip already notarized nodes
- refine notarization job to select nodes via `findByTxId(null)`

## Testing
- `mvn test` *(fails: mvn: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e103af380832faaf97db24c5fbbe5