### PR TITLE
Add Javadoc for EthereumAutoConfig

### DIFF
--- a/src/main/java/org/saidone/config/EthereumAutoConfig.java
+++ b/src/main/java/org/saidone/config/EthereumAutoConfig.java
@@ -10,8 +10,21 @@ import org.web3j.crypto.Keys;
 import org.web3j.utils.Numeric;
 
 @Configuration
+/**
+ * Auto-configuration that generates temporary Ethereum credentials.
+ * <p>
+ * When the property {@code application.service.ethereum.auto-generate} is set
+ * to {@code true}, an {@link EthereumCredentials} bean containing a newly
+ * created account address and private key is exposed.
+ */
 public class EthereumAutoConfig {
 
+    /**
+     * Generates a new Ethereum account and exposes the credentials as a bean.
+     *
+     * @return freshly generated credentials
+     * @throws Exception if key pair generation fails
+     */
     @Bean
     @ConditionalOnProperty(value = "application.service.ethereum.auto-generate", havingValue = "true")
     public EthereumCredentials ethereumCredentials() throws Exception {
@@ -23,8 +36,13 @@ public class EthereumAutoConfig {
     
     @Data
     @AllArgsConstructor
+    /**
+     * Holder for an Ethereum account address and its private key.
+     */
     public static class EthereumCredentials {
+        /** Ethereum account address beginning with {@code 0x}. */
         private String account;
+        /** Hex encoded private key without the {@code 0x} prefix. */
         private String privateKey;
     }
 


### PR DESCRIPTION
## Summary
- document EthereumAutoConfig and its generated bean

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f6afdb3cc832fb0225372a7bec2a8