### PR TITLE
Add Javadoc for model classes

### DIFF
--- a/src/main/java/org/saidone/model/Entry.java
+++ b/src/main/java/org/saidone/model/Entry.java
@@ -23,6 +23,10 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.alfresco.core.model.Node;
 
+/**
+ * Simple wrapper used when communicating with the Alfresco public API where
+ * responses are typically wrapped inside an {@code entry} JSON object.
+ */
 @AllArgsConstructor
 @Data
 public class Entry {

--- a/src/main/java/org/saidone/model/MetadataKeys.java
+++ b/src/main/java/org/saidone/model/MetadataKeys.java
@@ -18,13 +18,23 @@
 
 package org.saidone.model;
 
+/**
+ * Standard metadata keys used when storing node content in various backends.
+ * These constants provide a common naming convention across implementations.
+ */
 public interface MetadataKeys {
 
+    /** Name of the checksum algorithm (e.g. SHA-256). */
     String CHECKSUM_ALGORITHM = "chkAlg";
+    /** Hex encoded checksum value. */
     String CHECKSUM_VALUE = "chkVal";
+    /** MIME type associated with the stored content. */
     String CONTENT_TYPE = "_contentType";
+    /** Flag marking content as encrypted. */
     String ENCRYPTED = "enc";
+    /** Original file name. */
     String FILENAME = "filename";
+    /** Unique identifier of the stored object. */
     String UUID = "uuid";
 
 }

--- a/src/main/java/org/saidone/model/NodeContent.java
+++ b/src/main/java/org/saidone/model/NodeContent.java
@@ -21,12 +21,18 @@ package org.saidone.model;
 import lombok.Data;
 import org.springframework.data.mongodb.core.mapping.Field;
 
+/**
+ * Base class containing minimal information about node binary content. It is
+ * extended by descriptors carrying additional metadata or a content stream.
+ */
 @Data
 public abstract class NodeContent {
 
-     @Field("name")
-     public String fileName;
-     @Field("ct")
-     public String contentType;
+    /** Original file name. */
+    @Field("name")
+    public String fileName;
+    /** MIME type of the content. */
+    @Field("ct")
+    public String contentType;
 
 }

--- a/src/main/java/org/saidone/model/NodeContentInfo.java
+++ b/src/main/java/org/saidone/model/NodeContentInfo.java
@@ -22,16 +22,25 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.springframework.data.mongodb.core.mapping.Field;
 
+/**
+ * Metadata describing the archived content of a node. Extends
+ * {@link NodeContent} with additional information such as checksum and
+ * encryption status.
+ */
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class NodeContentInfo extends NodeContent {
 
+    /** Identifier of the stored content (e.g. GridFS id). */
     @Field("cid")
     private String contentId;
+    /** Hash algorithm used to generate {@link #contentHash}. */
     @Field("alg")
     private String contentHashAlgorithm;
+    /** Hexadecimal checksum of the content. */
     @Field("hash")
     private String contentHash;
+    /** Flag indicating whether the binary data is encrypted. */
     @Field("enc")
     private boolean encrypted;
 

--- a/src/main/java/org/saidone/model/NodeContentStream.java
+++ b/src/main/java/org/saidone/model/NodeContentStream.java
@@ -23,11 +23,18 @@ import lombok.EqualsAndHashCode;
 
 import java.io.InputStream;
 
+/**
+ * Descriptor representing a node's binary data as an {@link InputStream} along
+ * with its length. Extends {@link NodeContent} to also expose the file name and
+ * content type.
+ */
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class NodeContentStream extends NodeContent {
 
+    /** Size of the content in bytes. */
     private long length;
+    /** Stream providing access to the binary content. */
     private InputStream contentStream;
 
 }

--- a/src/main/java/org/saidone/model/NodeWrapper.java
+++ b/src/main/java/org/saidone/model/NodeWrapper.java
@@ -35,6 +35,12 @@ import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.time.Instant;
 
+/**
+ * MongoDB wrapper entity storing an Alfresco {@link Node} together with
+ * additional vault specific metadata. The JSON representation of the
+ * {@code Node} is persisted in the {@code nodeJson} field while metadata such
+ * as archival date or notarization id are stored in dedicated properties.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -62,10 +68,28 @@ public class NodeWrapper {
     @Field("ntx")
     private String notarizationTxId;
 
+    /**
+     * Convenience constructor creating a wrapper for the given node without
+     * any content information. It simply delegates to the two argument
+     * constructor.
+     *
+     * @param node the Alfresco node to wrap
+     * @throws IllegalArgumentException if {@code node} is {@code null}
+     * @throws JsonProcessingException  if the node cannot be serialized
+     */
     public NodeWrapper(Node node) throws IllegalArgumentException, JsonProcessingException {
         new NodeWrapper(node, null);
     }
 
+    /**
+     * Creates a wrapper for the provided Alfresco {@link Node} optionally
+     * carrying content metadata.
+     *
+     * @param node        the node to persist
+     * @param contentInfo optional content information or {@code null}
+     * @throws IllegalArgumentException if {@code node} is {@code null}
+     * @throws JsonProcessingException  if the node cannot be serialized to JSON
+     */
     public NodeWrapper(Node node, NodeContentInfo contentInfo) throws IllegalArgumentException, JsonProcessingException {
         if (node == null) {
             throw new IllegalArgumentException("Node cannot be null");
@@ -76,6 +100,13 @@ public class NodeWrapper {
         this.contentInfo = contentInfo;
     }
 
+    /**
+     * Deserializes the JSON stored in {@link #nodeJson} back into an
+     * {@link Node} instance.
+     *
+     * @return the deserialized Alfresco node
+     * @throws JsonProcessingException if the JSON cannot be parsed
+     */
     @SneakyThrows
     public Node getNode() {
         try {
@@ -87,6 +118,11 @@ public class NodeWrapper {
         }
     }
 
+    /**
+     * Creates a preconfigured {@link ObjectMapper} instance used to
+     * serialize and deserialize nodes. Dates are written in ISO format and
+     * unknown properties are ignored when reading.
+     */
     private static ObjectMapper createObjectMapper() {
         val mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());

--- a/src/main/java/org/saidone/model/SystemSearchRequest.java
+++ b/src/main/java/org/saidone/model/SystemSearchRequest.java
@@ -20,6 +20,10 @@ package org.saidone.model;
 
 import lombok.Data;
 
+/**
+ * DTO used for invoking the Alfresco System API search endpoint. It mirrors
+ * the minimal set of parameters supported by the service.
+ */
 @Data
 public class SystemSearchRequest {
 	

--- a/src/main/java/org/saidone/model/alfresco/AlfrescoContentModel.java
+++ b/src/main/java/org/saidone/model/alfresco/AlfrescoContentModel.java
@@ -18,6 +18,11 @@
 
 package org.saidone.model.alfresco;
 
+/**
+ * Constants representing the standard Alfresco content model. The file is
+ * generated using the Saidone content model tool and contains both type and
+ * aspect QNames.
+ */
 @SuppressWarnings("unused")
 public interface AlfrescoContentModel {
 

--- a/src/main/java/org/saidone/model/alfresco/AnvContentModel.java
+++ b/src/main/java/org/saidone/model/alfresco/AnvContentModel.java
@@ -18,6 +18,10 @@
 
 package org.saidone.model.alfresco;
 
+/**
+ * Constants for the Alfresco Node Vault custom content model. Generated using
+ * the Saidone content model tool.
+ */
 @SuppressWarnings("unused")
 public interface AnvContentModel {
 


### PR DESCRIPTION
## Summary
- document NodeWrapper and related model classes
- document custom Alfresco content model constants

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68713cb57c18832f9f7f9103873de1eb