### PR TITLE
Add Javadoc to notarization services

### DIFF
--- a/src/main/java/org/saidone/service/notarization/AbstractNotarizationService.java
+++ b/src/main/java/org/saidone/service/notarization/AbstractNotarizationService.java
@@ -17,6 +17,12 @@
  */
 
 package org.saidone.service.notarization;
+/**
+ * Base implementation for services performing document notarization.
+ *
+ * <p>This component provides the common logic for computing document hashes
+ * and updating Alfresco nodes after the hash has been persisted.</p>
+ */
 
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
@@ -37,10 +43,28 @@ public abstract class AbstractNotarizationService extends BaseComponent implemen
     @Value("${application.service.vault.hash-algorithm}")
     private String checksumAlgorithm;
 
+    /**
+     * Persists the given hash.
+     *
+     * @param nodeId the Alfresco node identifier used for logging
+     * @param hash   the hash value to store
+     * @return an implementation specific transaction id
+     */
     public abstract String putHash(String nodeId, String hash);
 
+    /**
+     * Retrieves the stored hash for the given transaction id.
+     *
+     * @param txId the transaction identifier
+     * @return the stored hash value
+     */
     public abstract String getHash(String txId);
 
+    /**
+     * Computes the hash of the node content and stores it through {@link #putHash}.
+     *
+     * @param nodeId the identifier of the node to notarize
+     */
     @SneakyThrows
     public void notarizeDocument(String nodeId) {
         log.debug("Notarizing document {}", nodeId);

--- a/src/main/java/org/saidone/service/notarization/EthereumService.java
+++ b/src/main/java/org/saidone/service/notarization/EthereumService.java
@@ -57,6 +57,13 @@ public class EthereumService extends AbstractNotarizationService {
     private Web3j web3j;
     private Credentials credentials;
 
+    /**
+     * Creates the service with required dependencies.
+     *
+     * @param nodeService    service used to interact with Alfresco nodes
+     * @param contentService service computing document hashes
+     * @param config         Ethereum configuration properties
+     */
     public EthereumService(NodeService nodeService, ContentService contentService, EthereumConfig config) {
         super(nodeService, contentService);
         this.config = config;
@@ -93,6 +100,12 @@ public class EthereumService extends AbstractNotarizationService {
     }
 
     @Override
+    /**
+     * Fetches the hash data stored in the given Ethereum transaction.
+     *
+     * @param txHash the transaction identifier
+     * @return the string stored in the transaction input data
+     */
     public String getHash(String txHash) {
         try {
             val ethTransaction = web3j.ethGetTransactionByHash(txHash).send();

--- a/src/main/java/org/saidone/service/notarization/NotarizationService.java
+++ b/src/main/java/org/saidone/service/notarization/NotarizationService.java
@@ -17,13 +17,37 @@
  */
 
 package org.saidone.service.notarization;
+/**
+ * Contract for components able to notarize Alfresco documents.
+ *
+ * <p>Implementations store document hashes in an external system such as a
+ * blockchain and later retrieve them.</p>
+ */
 
 public interface NotarizationService {
 
+    /**
+     * Retrieves the hash stored within the transaction identified by the given id.
+     *
+     * @param txHash the transaction identifier returned by {@link #putHash(String, String)}
+     * @return the persisted hash
+     */
     String getHash(String txHash);
 
+    /**
+     * Stores the supplied hash in the underlying notarization system.
+     *
+     * @param nodeId the Alfresco node identifier used for logging
+     * @param hash   the hash to store
+     * @return an implementation specific transaction id
+     */
     String putHash(String nodeId, String hash);
 
+    /**
+     * Computes and stores the hash for the given Alfresco node.
+     *
+     * @param nodeId the node whose content should be notarized
+     */
     void notarizeDocument(String nodeId);
 
 }


### PR DESCRIPTION
## Summary
- document NotarizationService interface and methods
- document AbstractNotarizationService and its hooks
- document EthereumService constructor and getHash method

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6872000ba1bc832fa93fda6c7a33a7d8