### PR TITLE
Add Javadoc to config classes

### DIFF
--- a/src/main/java/org/saidone/config/AlfrescoServiceConfig.java
+++ b/src/main/java/org/saidone/config/AlfrescoServiceConfig.java
@@ -27,10 +27,19 @@ import java.util.List;
 @Configuration
 @ConfigurationProperties(prefix = "application.service.alfresco")
 @Data
+/**
+ * Configuration properties used to access the Alfresco repository.
+ * <p>
+ * These values configure how nodes are fetched and deleted when
+ * interacting with Alfresco.
+ */
 public class AlfrescoServiceConfig {
 
+    /** Number of nodes retrieved per REST request. */
     private int searchBatchSize;
+    /** Whether nodes should be removed from Alfresco instead of archived. */
     private boolean permanentlyDeleteNodes;
+    /** List of additional properties to include in the Alfresco query. */
     private List<String> include;
 
 }

--- a/src/main/java/org/saidone/config/EncryptionConfig.java
+++ b/src/main/java/org/saidone/config/EncryptionConfig.java
@@ -32,39 +32,62 @@ import org.springframework.validation.annotation.Validated;
 @Data
 @ConfigurationProperties(prefix = "application.service.vault.encryption")
 @Validated
+/**
+ * Configuration properties for content encryption managed through Vault.
+ * <p>
+ * These settings define which secret to use for encryption and how key
+ * derivation is performed.
+ */
 public class EncryptionConfig {
 
+    /** Vault key/value mount path. */
     @Setter
     private String vaultSecretKvMount;
+    /** Path of the secret within Vault. */
     @Setter
     private String vaultSecretPath;
+    /** Key name of the secret used for encryption. */
     @Setter
     private String vaultSecretKey;
+    /** Fallback secret value when Vault is not available. */
     @Setter
     private String secret;
 
+    /** Key derivation configuration. */
     @Valid
     @NotNull
     private AbstractCryptoService.Kdf kdf;
 
+    /** JCA provider specific parameters. */
     @Valid
     private JcaProperties jca;
 
+    /** BouncyCastle provider specific parameters. */
     @Valid
     private BcProperties bc;
 
+    /**
+     * Java Cryptography Architecture related parameters.
+     */
     @Data
     public static class JcaProperties {
+        /** Length in bytes of the random salt. */
         @Min(16)
         private int saltLength;
+        /** Length in bytes of the initialization vector. */
         @Min(12)
         private int ivLength;
     }
 
+    /**
+     * Bouncy Castle provider related parameters.
+     */
     @Data
     public static class BcProperties {
+        /** Length in bytes of the random salt. */
         @Min(16)
         private int saltLength;
+        /** Length in bytes of the nonce. */
         @Min(12)
         private int nonceLength;
     }

--- a/src/main/java/org/saidone/config/FeignConfig.java
+++ b/src/main/java/org/saidone/config/FeignConfig.java
@@ -24,6 +24,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 
 @Configuration
+/**
+ * Customizes Feign HTTP message converters used by the Alfresco client.
+ */
 public class FeignConfig {
 
     @Bean

--- a/src/main/java/org/saidone/config/MongoDBConfig.java
+++ b/src/main/java/org/saidone/config/MongoDBConfig.java
@@ -33,6 +33,9 @@ import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
 
 @Configuration
+/**
+ * Configures the MongoDB client used to store vault metadata.
+ */
 public class MongoDBConfig extends AbstractMongoClientConfiguration {
 
     @Value("${spring.data.mongodb.uri}")

--- a/src/main/java/org/saidone/config/OpenApiConfig.java
+++ b/src/main/java/org/saidone/config/OpenApiConfig.java
@@ -30,5 +30,8 @@ import org.springframework.context.annotation.Configuration;
         scheme = "basic"
 )
 @SecurityRequirement(name = "basicAuth")
+/**
+ * Registers OpenAPI components and security scheme for the REST API.
+ */
 public class OpenApiConfig {
 }

--- a/src/main/java/org/saidone/config/S3Config.java
+++ b/src/main/java/org/saidone/config/S3Config.java
@@ -15,6 +15,9 @@ import java.net.URI;
 @Configuration
 @ConfigurationProperties(prefix = "application.service.vault.storage.s3")
 @Data
+/**
+ * Configuration for the Amazon S3 client used as storage backend.
+ */
 public class S3Config {
 
     private String key;

--- a/src/main/java/org/saidone/config/SecurityConfig.java
+++ b/src/main/java/org/saidone/config/SecurityConfig.java
@@ -38,6 +38,9 @@ import static org.springframework.security.config.Customizer.withDefaults;
 @ConfigurationProperties(prefix = "management.security.basic-auth")
 @Setter
 @EnableWebFluxSecurity
+/**
+ * Basic security configuration securing the actuator endpoints.
+ */
 public class SecurityConfig {
 
     private String username;


### PR DESCRIPTION
## Summary
- document the Alfresco service configuration class
- document encryption configuration options
- document Feign, MongoDB, OpenAPI, S3 and security config classes

## Testing
- `mvn test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687200277d4c832f9b0fdc904423107d