### PR TITLE
Improve documentation for vault services

### DIFF
--- a/src/main/java/org/saidone/controller/VaultApiController.java
+++ b/src/main/java/org/saidone/controller/VaultApiController.java
@@ -329,10 +329,11 @@ public class VaultApiController {
     }
 
     /**
-     * Check notarization of a node.
+     * Checks the notarization status of a node and returns the current result.
      *
      * @param auth   optional Basic authentication header
      * @param nodeId identifier of the node to be checked
+     * @return confirmation message or an empty body if not yet notarized
      */
     @SecurityRequirement(name = "basicAuth")
     @GetMapping("/nodes/{nodeId}/notarize")

--- a/src/main/java/org/saidone/repository/EncryptedS3RepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/EncryptedS3RepositoryImpl.java
@@ -68,7 +68,8 @@ public class EncryptedS3RepositoryImpl extends S3RepositoryImpl {
      *
      * @param bucketName  destination bucket
      * @param node        node whose id acts as the key
-     * @param metadata
+     * @param metadata    optional object metadata to associate with the stored
+     *                    object
      * @param inputStream content stream to encrypt and upload
      */
     @Override

--- a/src/main/java/org/saidone/repository/S3Repository.java
+++ b/src/main/java/org/saidone/repository/S3Repository.java
@@ -35,7 +35,8 @@ public interface S3Repository {
      *
      * @param bucketName  name of the target S3 bucket
      * @param node        node whose identifier will be used as the object key
-     * @param metadata
+     * @param metadata    optional object metadata to store alongside the binary
+     *                    content
      * @param inputStream the stream providing the content to store
      */
     void putObject(String bucketName, Node node, HashMap<String, String> metadata, InputStream inputStream);

--- a/src/main/java/org/saidone/repository/S3RepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/S3RepositoryImpl.java
@@ -63,7 +63,8 @@ public class S3RepositoryImpl extends BaseComponent implements S3Repository {
      *
      * @param bucketName  destination bucket
      * @param node        node whose id acts as the key
-     * @param metadata
+     * @param metadata    optional object metadata to associate with the stored
+     *                    content
      * @param inputStream stream of the content to store
      */
     @Override

--- a/src/main/java/org/saidone/service/content/ContentService.java
+++ b/src/main/java/org/saidone/service/content/ContentService.java
@@ -47,6 +47,14 @@ public interface ContentService {
      */
     NodeContentStream getNodeContent(String nodeId);
 
+    /**
+     * Retrieves only metadata information about the stored content of the given
+     * node without returning the binary stream.
+     *
+     * @param nodeId identifier of the node
+     * @return a {@link NodeContentInfo} descriptor populated with file name,
+     *         content type and checksum details
+     */
     NodeContentInfo getNodeContentInfo(String nodeId);
 
     /**

--- a/src/main/java/org/saidone/service/content/GridFsContentService.java
+++ b/src/main/java/org/saidone/service/content/GridFsContentService.java
@@ -114,10 +114,37 @@ public class GridFsContentService implements ContentService {
         return nodeContent;
     }
 
+    /**
+     * Retrieves metadata information about a node's content stored in GridFS.
+     *
+     * @param nodeId identifier of the node
+     * @return a {@link NodeContentInfo} describing the stored content
+     * @throws NodeNotFoundOnVaultException if the node content cannot be found
+     */
     @Override
     public NodeContentInfo getNodeContentInfo(String nodeId) {
-        // TODO implementation
-        return null;
+        val gridFSFile = gridFsRepository.findFileById(nodeId);
+        if (gridFSFile == null) {
+            throw new NodeNotFoundOnVaultException(nodeId);
+        }
+        val info = new NodeContentInfo();
+        info.setContentId(nodeId);
+        info.setFileName(gridFSFile.getFilename());
+        if (gridFSFile.getMetadata() != null) {
+            if (gridFSFile.getMetadata().containsKey(MetadataKeys.CONTENT_TYPE)) {
+                info.setContentType(gridFSFile.getMetadata().getString(MetadataKeys.CONTENT_TYPE));
+            }
+            if (gridFSFile.getMetadata().containsKey(MetadataKeys.CHECKSUM_ALGORITHM)) {
+                info.setContentHashAlgorithm(gridFSFile.getMetadata().getString(MetadataKeys.CHECKSUM_ALGORITHM));
+            }
+            if (gridFSFile.getMetadata().containsKey(MetadataKeys.CHECKSUM_VALUE)) {
+                info.setContentHash(gridFSFile.getMetadata().getString(MetadataKeys.CHECKSUM_VALUE));
+            }
+            if (gridFSFile.getMetadata().containsKey(MetadataKeys.ENCRYPTED)) {
+                info.setEncrypted(Boolean.TRUE.equals(gridFSFile.getMetadata().getBoolean(MetadataKeys.ENCRYPTED)));
+            }
+        }
+        return info;
     }
 
     /**

--- a/src/main/java/org/saidone/service/content/S3ContentService.java
+++ b/src/main/java/org/saidone/service/content/S3ContentService.java
@@ -130,6 +130,14 @@ public class S3ContentService extends BaseComponent implements ContentService {
         }
     }
 
+    /**
+     * Retrieves only the metadata of a node's content stored in S3 without
+     * streaming the actual binary.
+     *
+     * @param nodeId identifier of the node
+     * @return a populated {@link NodeContentInfo}
+     * @throws NodeNotFoundOnVaultException if the object does not exist in S3
+     */
     @Override
     public NodeContentInfo getNodeContentInfo(String nodeId) {
         try {


### PR DESCRIPTION
## Summary
- clarify the Javadoc for S3 repository APIs
- document ContentService and its implementations
- implement GridFsContentService#getNodeContentInfo
- expand API docs for notarization check

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687251f88b70832f88292d52fc01b8e7