### PR TITLE
Add javadoc for audit keys and MongoDB field mappings

### DIFF
--- a/src/main/java/org/saidone/audit/AuditEntry.java
+++ b/src/main/java/org/saidone/audit/AuditEntry.java
@@ -21,6 +21,9 @@ package org.saidone.audit;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import static org.saidone.audit.AuditMetadataKeys.*;
 
 import java.io.Serializable;
 import java.time.Instant;
@@ -38,8 +41,14 @@ public class AuditEntry {
 
     @Id
     private String id;
+
+    @Field(TIMESTAMP)
     private Instant timestamp;
+
+    @Field(METADATA)
     private Map<String, Serializable> metadata;
+
+    @Field(TYPE)
     private String type;
 
 }

--- a/src/main/java/org/saidone/audit/AuditMetadataKeys.java
+++ b/src/main/java/org/saidone/audit/AuditMetadataKeys.java
@@ -18,17 +18,35 @@
 
 package org.saidone.audit;
 
+/**
+ * Abbreviated MongoDB field names and audit metadata keys used throughout the
+ * auditing subsystem. These constants keep the stored documents small while
+ * providing a single point of reference for the mapping between Java fields and
+ * their persisted counterparts.
+ */
 public interface AuditMetadataKeys {
 
+    /** Field name for the audit entry timestamp. */
     String TIMESTAMP = "ts";
+    /** Field name for the metadata document. */
     String METADATA = "md";
+    /** Field name for the entry type. */
+    String TYPE = "typ";
 
+    /** Client IP address. */
     String IP = "ip";
+    /** HTTP {@code User-Agent} header value. */
     String USER_AGENT = "usrag";
+    /** Requested path. */
     String PATH = "path";
+    /** HTTP method. */
     String METHOD = "meth";
+
+    /** Constant identifying request audit entries. */
     String REQUEST = "req";
+    /** HTTP response status code. */
     String STATUS = "st";
+    /** Constant identifying response audit entries. */
     String RESPONSE = "res";
 
 }


### PR DESCRIPTION
## Summary
- document constants in `AuditMetadataKeys`
- map `AuditEntry` fields to abbreviated MongoDB names

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6875f25ad444832fab0092da5e22c061