### PR TITLE
Fix misplaced javadoc

### DIFF
--- a/src/main/java/org/saidone/service/notarization/AbstractNotarizationService.java
+++ b/src/main/java/org/saidone/service/notarization/AbstractNotarizationService.java
@@ -17,12 +17,6 @@
  */
 
 package org.saidone.service.notarization;
-/**
- * Base implementation for services performing document notarization.
- *
- * <p>This component provides the common logic for computing document hashes
- * and updating nodes after the hash has been persisted.</p>
- */
 
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
@@ -35,6 +29,12 @@ import org.springframework.beans.factory.annotation.Value;
 
 @RequiredArgsConstructor
 @Slf4j
+/**
+ * Base implementation for services performing document notarization.
+ *
+ * <p>This component provides the common logic for computing document hashes
+ * and updating nodes after the hash has been persisted.</p>
+ */
 public abstract class AbstractNotarizationService extends BaseComponent implements NotarizationService {
 
     private final NodeService nodeService;


### PR DESCRIPTION
## Summary
- move class javadoc inside `AbstractNotarizationService`

## Testing
- `mvn -q -DskipTests=true -e compile` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687749c743f8832f89e9d10bfc6c26ad