### PR TITLE
Add javadoc for notarization components

### DIFF
--- a/src/main/java/org/saidone/exception/NotarizationException.java
+++ b/src/main/java/org/saidone/exception/NotarizationException.java
@@ -18,7 +18,21 @@
 
 package org.saidone.exception;
 
+/**
+ * Raised to signal a failure while persisting or retrieving notarization data.
+ * <p>
+ * It wraps any lower level exception coming from the underlying blockchain or
+ * storage implementation so that callers can react uniformly to notarization
+ * errors.
+ * </p>
+ */
 public class NotarizationException extends VaultException {
+
+    /**
+     * Creates a new instance with the provided error message.
+     *
+     * @param message description of the failure
+     */
     public NotarizationException(String message) {
         super(message);
     }

--- a/src/main/java/org/saidone/service/notarization/EthereumService.java
+++ b/src/main/java/org/saidone/service/notarization/EthereumService.java
@@ -117,13 +117,13 @@ public class EthereumService extends AbstractNotarizationService {
         super.stop();
     }
 
-    @Override
     /**
      * Fetches the hash data stored in the given Ethereum transaction.
      *
      * @param txHash the transaction identifier
      * @return the string stored in the transaction input data
      */
+    @Override
     public String getHash(String txHash) {
         try {
             val ethTransaction = web3j.ethGetTransactionByHash(txHash).send();


### PR DESCRIPTION
## Summary
- document periodic document notarization job
- clarify Ethereum service javadoc placement
- describe NotarizationException class

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68789ea65b8c832f8e28814c3c6e126a