### PR TITLE
Add missing Javadoc comments

### DIFF
--- a/src/main/java/org/saidone/controller/VaultApiController.java
+++ b/src/main/java/org/saidone/controller/VaultApiController.java
@@ -144,6 +144,12 @@ public class VaultApiController {
                 .body("Server memory limit exceeded. Please try with a smaller file or contact administrator.");
     }
 
+    /**
+     * Handles errors related to the notarization process.
+     *
+     * @param e the thrown {@link NotarizationException}
+     * @return an internal server error response containing the exception message
+     */
     @ExceptionHandler(NotarizationException.class)
     @Operation(hidden = true)
     public ResponseEntity<String> handleNotarizationException(NotarizationException e) {

--- a/src/main/java/org/saidone/service/notarization/AbstractNotarizationService.java
+++ b/src/main/java/org/saidone/service/notarization/AbstractNotarizationService.java
@@ -29,14 +29,14 @@ import org.saidone.service.NodeService;
 import org.saidone.service.content.ContentService;
 import org.springframework.beans.factory.annotation.Value;
 
-@RequiredArgsConstructor
-@Slf4j
 /**
  * Base implementation for services performing document notarization.
  *
  * <p>This component provides the common logic for computing document hashes
  * and updating nodes after the hash has been persisted.</p>
  */
+@RequiredArgsConstructor
+@Slf4j
 public abstract class AbstractNotarizationService extends BaseComponent implements NotarizationService {
 
     private final NodeService nodeService;
@@ -77,6 +77,16 @@ public abstract class AbstractNotarizationService extends BaseComponent implemen
         nodeService.save(nodeWrapper);
     }
 
+    /**
+     * Validates that the notarization for the specified node is still valid.
+     *
+     * <p>The method retrieves the stored transaction id from the node,
+     * fetches the hash back from the notarization system and compares it with
+     * the hash computed from the current content.</p>
+     *
+     * @param nodeId the identifier of the node to check
+     * @throws NotarizationException if the node is not notarized or hashes do not match
+     */
     @SneakyThrows
     public void checkNotarization(String nodeId) {
         log.debug("Checking notarization for document {}", nodeId);

--- a/src/main/java/org/saidone/service/notarization/NotarizationService.java
+++ b/src/main/java/org/saidone/service/notarization/NotarizationService.java
@@ -50,6 +50,14 @@ public interface NotarizationService {
      */
     void notarizeNode(String nodeId);
 
+    /**
+     * Verifies that the stored hash for the given node matches the hash of its
+     * current content.
+     *
+     * @param nodeId the node whose notarization should be validated
+     * @throws org.saidone.exception.NotarizationException if the node is not
+     *                                                      notarized or hashes do not match
+     */
     void checkNotarization(String nodeId);
 
 }


### PR DESCRIPTION
## Summary
- document `handleNotarizationException` in `VaultApiController`
- move and expand Javadoc in `AbstractNotarizationService`
- add documentation for `checkNotarization` in `NotarizationService`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_687dddeec5a8832fafa2f074b2d7d28e