### PR TITLE
Improve javadoc for notarization services

### DIFF
--- a/src/main/java/org/saidone/service/notarization/AbstractNotarizationService.java
+++ b/src/main/java/org/saidone/service/notarization/AbstractNotarizationService.java
@@ -32,16 +32,28 @@ import org.springframework.beans.factory.annotation.Value;
 /**
  * Base implementation for services performing document notarization.
  *
- * <p>This component provides the common logic for computing document hashes
- * and updating nodes after the hash has been persisted.</p>
+ * <p>
+ *   Concrete implementations only need to provide the mechanisms used to
+ *   persist and read back document hashes via {@link #putHash(String, String)}
+ *   and {@link #getHash(String)}. All other operations such as computing the
+ *   hash of a node's content and updating the node metadata are handled here.
+ * </p>
  */
 @RequiredArgsConstructor
 @Slf4j
 public abstract class AbstractNotarizationService extends BaseComponent implements NotarizationService {
 
+    /** Service used to access nodes and their metadata. */
     private final NodeService nodeService;
+
+    /** Service providing access to node content for hashing. */
     private final ContentService contentService;
 
+    /**
+     * Algorithm used when computing hashes of node content. Value is read from
+     * the {@code application.service.vault.hash-algorithm} configuration
+     * property.
+     */
     @Value("${application.service.vault.hash-algorithm}")
     private String checksumAlgorithm;
 

--- a/src/main/java/org/saidone/service/notarization/EthereumService.java
+++ b/src/main/java/org/saidone/service/notarization/EthereumService.java
@@ -42,10 +42,13 @@ import java.nio.charset.StandardCharsets;
 /**
  * Service responsible for interacting with an Ethereum node to store document hashes.
  *
- * <p>This component wraps the minimal Web3j interactions required by the
- * application. It creates the {@link Web3j} client on startup and uses the
- * provided {@link Credentials} to sign transactions that embed document
- * hashes.</p>
+ * <p>
+ *     This component wraps the minimal Web3j interactions required by the
+ *     application. It creates the {@link Web3j} client on startup and uses the
+ *     provided {@link Credentials} to sign transactions that embed document
+ *     hashes. The bean is instantiated only when the application is configured
+ *     to use the {@code ethereum} implementation of the notarization service.
+ * </p>
  */
 @Service
 @Slf4j
@@ -70,8 +73,9 @@ public class EthereumService extends AbstractNotarizationService {
     private Credentials credentials;
 
     /**
-     * Null-recipient address used when sending transactions containing only
-     * notarization data.
+     * Null-recipient address used when broadcasting transactions that solely
+     * contain notarization data. The Ethereum network ignores the recipient when
+     * no value is transferred, therefore this placeholder is sufficient.
      */
     private static final String TO = "0x0000000000000000000000000000000000000000";
 

--- a/src/main/java/org/saidone/service/notarization/NotarizationService.java
+++ b/src/main/java/org/saidone/service/notarization/NotarizationService.java
@@ -21,8 +21,12 @@ package org.saidone.service.notarization;
 /**
  * Contract for components able to notarize documents.
  *
- * <p>Implementations store document hashes in an external system such as a
- * blockchain and later retrieve them.</p>
+ * <p>
+ *     Implementations are responsible for persisting hashes of a node's
+ *     content to an external store (for example a blockchain) and for
+ *     retrieving them afterwards. {@link AbstractNotarizationService} provides
+ *     a base implementation of the common logic.
+ * </p>
  */
 
 public interface NotarizationService {


### PR DESCRIPTION
## Summary
- document dependency fields and configuration details in AbstractNotarizationService
- expand interface level explanation for NotarizationService
- clarify EthereumService class and constant javadoc

## Testing
- `mvn --version` *(fails: command not found)*
- `apt-get install -y maven` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_687f2624519c832f8207c87ed24f4bd9