### PR TITLE
Improve audit classes javadoc

### DIFF
--- a/src/main/java/org/saidone/audit/AuditEntry.java
+++ b/src/main/java/org/saidone/audit/AuditEntry.java
@@ -51,6 +51,11 @@ public class AuditEntry {
     @Field(TYPE)
     private String type;
 
+    /**
+     * Creates a new {@code AuditEntry} with its timestamp set to the
+     * current instant. The metadata and type can be populated later
+     * before persisting the entry.
+     */
     public AuditEntry() {
         this.timestamp = Instant.now();
     }

--- a/src/main/java/org/saidone/audit/AuditMetadataKeys.java
+++ b/src/main/java/org/saidone/audit/AuditMetadataKeys.java
@@ -33,6 +33,7 @@ public interface AuditMetadataKeys {
     /** Field name for the entry type. */
     String TYPE = "typ";
 
+    /** Request/response identifier. */
     String ID = "id";
     /** Client IP address. */
     String IP = "ip";

--- a/src/main/java/org/saidone/audit/AuditService.java
+++ b/src/main/java/org/saidone/audit/AuditService.java
@@ -44,10 +44,24 @@ public class AuditService extends BaseComponent {
 
     private final MongoTemplate mongoTemplate;
 
+    /**
+     * Persist the provided audit entry in MongoDB.
+     *
+     * @param auditEntry the entry to store
+     */
     public void saveEntry(AuditEntry auditEntry) {
         mongoTemplate.insert(auditEntry);
     }
 
+    /**
+     * Retrieve audit entries filtered by type and timestamp.
+     *
+     * @param type     optional entry type to filter by
+     * @param from     lower bound of the timestamp range (inclusive)
+     * @param to       upper bound of the timestamp range (inclusive)
+     * @param pageable paging information
+     * @return list of matching audit entries ordered by timestamp descending
+     */
     public List<AuditEntry> findEntries(String type, Instant from, Instant to, Pageable pageable) {
         val criteriaList = new ArrayList<Criteria>();
         if (type != null) {

--- a/src/main/java/org/saidone/audit/AuditWebFilter.java
+++ b/src/main/java/org/saidone/audit/AuditWebFilter.java
@@ -50,6 +50,14 @@ public class AuditWebFilter extends BaseComponent implements WebFilter {
 
     private final AuditService auditService;
 
+    /**
+     * Intercepts the request/response exchange to persist basic audit
+     * information.
+     *
+     * @param exchange the current server exchange
+     * @param chain    the remaining web filter chain
+     * @return completion signal for the filter chain
+     */
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
         val requestEntry = createRequestAuditEntry(exchange.getRequest());
@@ -60,6 +68,12 @@ public class AuditWebFilter extends BaseComponent implements WebFilter {
         });
     }
 
+    /**
+     * Build an audit entry representing an incoming HTTP request.
+     *
+     * @param request the server request
+     * @return populated audit entry for the request
+     */
     public static AuditEntry createRequestAuditEntry(ServerHttpRequest request) {
         val metadata = new HashMap<String, Serializable>();
         metadata.put(AuditMetadataKeys.ID, request.getId());
@@ -75,6 +89,13 @@ public class AuditWebFilter extends BaseComponent implements WebFilter {
         return entry;
     }
 
+    /**
+     * Build an audit entry representing an HTTP response.
+     *
+     * @param id       identifier of the related request
+     * @param response the server response
+     * @return populated audit entry for the response
+     */
     public static AuditEntry createResponseAuditEntry(String id, ServerHttpResponse response) {
         val metadata = new HashMap<String, Serializable>();
         metadata.put(AuditMetadataKeys.ID, id);


### PR DESCRIPTION
## Summary
- add javadoc on `AuditEntry` constructor
- document all constants in `AuditMetadataKeys`
- add method javadoc to `AuditService`
- describe `AuditWebFilter` methods

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6881cce70214832f8329d1720309232a