### PR TITLE
Improve audit javadocs

### DIFF
--- a/src/main/java/org/saidone/controller/AuditApiController.java
+++ b/src/main/java/org/saidone/controller/AuditApiController.java
@@ -44,7 +44,9 @@ public class AuditApiController {
      * @param auth optional Basic authentication header
      * @param type filter by entry type
      * @param from start timestamp (inclusive)
-     * @param to   end timestamp (inclusive)
+     * @param to        end timestamp (inclusive)
+     * @param maxItems  maximum number of items to return
+     * @param skipCount number of items to skip (for pagination)
      * @return the list of matching audit entries
      */
     @SecurityRequirement(name = "basicAuth")

--- a/src/main/java/org/saidone/service/audit/AuditService.java
+++ b/src/main/java/org/saidone/service/audit/AuditService.java
@@ -21,10 +21,32 @@ package org.saidone.service.audit;
 import java.time.Instant;
 import java.util.List;
 
+/**
+ * Service abstraction for persisting and querying {@link AuditEntry} objects.
+ * <p>
+ * Implementations are responsible for storing audit entries and retrieving
+ * them using optional search criteria such as type or timestamp range.
+ * </p>
+ */
 public interface AuditService {
 
+    /**
+     * Persist the provided audit entry.
+     *
+     * @param auditEntry the entry to store
+     */
     void saveEntry(AuditEntry auditEntry);
 
+    /**
+     * Retrieve stored audit entries.
+     *
+     * @param type      optional entry type to filter by
+     * @param from      lower bound of the timestamp range (inclusive)
+     * @param to        upper bound of the timestamp range (inclusive)
+     * @param maxItems  maximum number of items to return
+     * @param skipCount number of items to skip (for pagination)
+     * @return list of matching audit entries ordered by timestamp descending
+     */
     List<AuditEntry> findEntries(String type, Instant from, Instant to, int maxItems, int skipCount);
 
 }

--- a/src/main/java/org/saidone/service/audit/AuditServiceImpl.java
+++ b/src/main/java/org/saidone/service/audit/AuditServiceImpl.java
@@ -56,9 +56,11 @@ public class AuditServiceImpl extends BaseComponent implements AuditService {
     /**
      * Retrieve audit entries filtered by type and timestamp.
      *
-     * @param type     optional entry type to filter by
-     * @param from     lower bound of the timestamp range (inclusive)
-     * @param to       upper bound of the timestamp range (inclusive)
+     * @param type      optional entry type to filter by
+     * @param from      lower bound of the timestamp range (inclusive)
+     * @param to        upper bound of the timestamp range (inclusive)
+     * @param maxItems  maximum number of items to return
+     * @param skipCount number of items to skip (for pagination)
      * @return list of matching audit entries ordered by timestamp descending
      */
     @Override

--- a/src/test/java/org/saidone/test/AuditApiControllerTests.java
+++ b/src/test/java/org/saidone/test/AuditApiControllerTests.java
@@ -36,6 +36,9 @@ import java.util.Base64;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * Integration tests for {@link org.saidone.controller.AuditApiController}.
+ */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 @Slf4j


### PR DESCRIPTION
## Summary
- document AuditService interface
- document pagination parameters in AuditServiceImpl and AuditApiController
- add javadoc header to AuditApiControllerTests

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6883235d2620832fa2312b2df40fc942