### PR TITLE
Add missing javadoc

### DIFF
--- a/src/main/java/org/saidone/service/SecretService.java
+++ b/src/main/java/org/saidone/service/SecretService.java
@@ -51,6 +51,14 @@ public class SecretService extends BaseComponent {
 
     private static VaultVersionedKeyValueOperations vaultVersionedKeyValueOperations;
 
+    /**
+     * Initializes the service after dependency injection.
+     * <p>
+     * Sets up the {@link VaultVersionedKeyValueOperations} instance used to
+     * retrieve secrets and verifies that Vault is initialized. If Vault is not
+     * initialized, the application is gracefully shut down.
+     * </p>
+     */
     @Override
     public void init() {
         super.init();
@@ -77,6 +85,13 @@ public class SecretService extends BaseComponent {
         }
     }
 
+    /**
+     * Asynchronously fetches a secret from Vault.
+     *
+     * @param version version of the secret to retrieve; {@code null} for the
+     *                latest version
+     * @return a future yielding the secret data and version
+     */
     private CompletableFuture<Key> getSecretAsync(Integer version) {
         return CompletableFuture.supplyAsync(() -> {
             Versioned<Map<String, Object>> response;
@@ -90,7 +105,9 @@ public class SecretService extends BaseComponent {
                         .version(response.getMetadata().getVersion().getVersion())
                         .data(((Map<?, ?>) response.getData()).get(properties.getVaultSecretKey()).toString().getBytes(StandardCharsets.UTF_8))
                         .build();
-            } else throw new RuntimeException("Unable to retrieve secret from vault");
+            } else {
+                throw new RuntimeException("Unable to retrieve secret from vault");
+            }
         });
     }
 

--- a/src/main/java/org/saidone/service/crypto/AbstractCryptoService.java
+++ b/src/main/java/org/saidone/service/crypto/AbstractCryptoService.java
@@ -46,7 +46,14 @@ public abstract class AbstractCryptoService extends BaseComponent implements Cry
     @NotNull
     protected Kdf kdf;
 
-    // with version == null we retrieve the last version
+    /**
+     * Convenience overload of {@link #deriveSecretKey(String, byte[], Integer)}
+     * that derives a key using the latest secret version.
+     *
+     * @param algorithm the algorithm for which the key is intended
+     * @param salt      salt value used during key derivation
+     * @return the derived key specification paired with the secret version
+     */
     protected Pair<SecretKeySpec, Integer> deriveSecretKey(String algorithm, byte[] salt) {
         return deriveSecretKey(algorithm, salt, null);
     }
@@ -72,7 +79,12 @@ public abstract class AbstractCryptoService extends BaseComponent implements Cry
     }
 
     /**
-     * Derives a secret key using PBKDF2 key derivation function
+     * Derives a secret key using the PBKDF2 algorithm.
+     *
+     * @param algorithm the target algorithm of the resulting key
+     * @param salt      the salt to use for key derivation
+     * @param version   the secret version used to obtain the master key
+     * @return a pair containing the derived key and the version number
      */
     private Pair<SecretKeySpec, Integer> derivePbkdf2SecretKey(String algorithm, byte[] salt, Integer version) {
         try {
@@ -87,7 +99,12 @@ public abstract class AbstractCryptoService extends BaseComponent implements Cry
     }
 
     /**
-     * Derives a secret key using HKDF key derivation function
+     * Derives a secret key using the HKDF key derivation function.
+     *
+     * @param algorithm the target algorithm of the resulting key
+     * @param salt      the salt value used for the HKDF extraction phase
+     * @param version   the secret version used to retrieve the master secret
+     * @return a pair containing the derived key and the version number
      */
     private Pair<SecretKeySpec, Integer> deriveHkdfSecretKey(String algorithm, byte[] salt, Integer version) {
         val hkdf = new HKDFBytesGenerator(new SHA256Digest());
@@ -101,7 +118,12 @@ public abstract class AbstractCryptoService extends BaseComponent implements Cry
     }
 
     /**
-     * Derives a secret key using Argon2 key derivation function
+     * Derives a secret key using the Argon2 key derivation function.
+     *
+     * @param algorithm the target algorithm of the resulting key
+     * @param salt      the salt to use for key derivation
+     * @param version   the secret version used to retrieve the master secret
+     * @return a pair containing the derived key and the version number
      */
     private Pair<SecretKeySpec, Integer> deriveArgon2SecretKey(String algorithm, byte[] salt, int version) {
         val builder = new Argon2Parameters.Builder(Argon2Parameters.ARGON2_id)
@@ -119,22 +141,36 @@ public abstract class AbstractCryptoService extends BaseComponent implements Cry
     }
 
     /**
-     * Configuration class for key derivation function settings
-     * Contains nested configuration classes for PBKDF2, HKDF and Argon2
+     * Configuration holder for key derivation settings.
+     * <p>
+     * The {@code impl} property selects the KDF implementation to use while the
+     * nested classes expose specific configuration options for PBKDF2, HKDF and
+     * Argon2.
+     * </p>
      */
     @Validated
     @Data
     public static class Kdf {
+        /**
+         * Selected key derivation implementation: {@code pbkdf2}, {@code hkdf}
+         * or {@code argon2}.
+         */
         @NotBlank(message = "The 'impl' field of Kdf is required")
         @Pattern(
                 regexp = "pbkdf2|hkdf|argon2",
                 message = "The 'impl' field of Kdf must be either 'pbkdf2', 'hkdf' or 'argon2'"
         )
         private String impl;
+
+        /** PBKDF2 specific options. */
         @Valid
         private Pbkdf2 pbkdf2;
+
+        /** HKDF specific options. */
         @Valid
         private Hkdf hkdf;
+
+        /** Argon2 specific options. */
         @Valid
         private Argon2 argon2;
 
@@ -143,7 +179,10 @@ public abstract class AbstractCryptoService extends BaseComponent implements Cry
          */
         @Data
         public static class Pbkdf2 {
+            /** JCA algorithm name for key derivation. */
             private static final String PBKDF2_KEY_FACTORY_ALGORITHM = "PBKDF2WithHmacSHA256";
+
+            /** Number of hashing iterations to perform. */
             @Min(100000)
             private Integer iterations = 100000;
         }
@@ -153,6 +192,7 @@ public abstract class AbstractCryptoService extends BaseComponent implements Cry
          */
         @Data
         public static class Hkdf {
+            /** Context string used as HKDF info parameter. */
             @NotBlank(message = "The 'info' field of HKDF is required")
             private String info;
         }
@@ -162,10 +202,15 @@ public abstract class AbstractCryptoService extends BaseComponent implements Cry
          */
         @Data
         public static class Argon2 {
+            /** Number of parallel threads. */
             @Min(1)
             private Integer parallelism = 1;
+
+            /** Memory cost in kilobytes. */
             @Min(65536)
             private Integer memory;
+
+            /** Iteration count. */
             @Min(3)
             private Integer iterations;
         }

--- a/src/main/java/org/saidone/service/crypto/Key.java
+++ b/src/main/java/org/saidone/service/crypto/Key.java
@@ -21,11 +21,22 @@ package org.saidone.service.crypto;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * Simple data holder for a secret retrieved from Vault.
+ * Contains the raw secret bytes and the version they belong to.
+ */
 @Builder
 @Data
 public class Key {
 
+    /**
+     * Version of the secret stored in Vault.
+     */
     public int version;
+
+    /**
+     * Raw secret bytes retrieved from Vault.
+     */
     public byte[] data;
 
 }


### PR DESCRIPTION
## Summary
- document SecretService initialization and async secret retrieval
- expand encryption service key derivation docs
- document Vault secret key model

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6885e0000840832f8ba188acbb69410d