### PR TITLE
Update javadocs for secret handling

### DIFF
--- a/src/main/java/org/saidone/service/SecretService.java
+++ b/src/main/java/org/saidone/service/SecretService.java
@@ -70,6 +70,16 @@ public class SecretService extends BaseComponent {
         }
     }
 
+    /**
+     * Retrieves the latest version of the secret from Vault.
+     *
+     * <p>This is a convenience method that delegates to
+     * {@link #getSecret(Integer)} with a {@code null} version</p>
+     * to fetch the most recent secret value.</p>
+     *
+     * @return the secret containing the raw bytes and version information
+     * @throws RuntimeException if the secret cannot be retrieved
+     */
     public Secret getSecret() {
         try {
             return getSecretAsync(null).get();

--- a/src/main/java/org/saidone/service/crypto/Secret.java
+++ b/src/main/java/org/saidone/service/crypto/Secret.java
@@ -22,15 +22,19 @@ import lombok.Builder;
 import lombok.Data;
 
 /**
- * Simple data holder for a secret retrieved from Vault.
- * Contains the raw secret bytes and the version they belong to.
+ * Container for a secret value retrieved from Vault.
+ * <p>
+ * Instances of this class are produced by {@link org.saidone.service.SecretService}
+ * when fetching encryption material. The {@link #version} corresponds to the
+ * version number reported by Vault while {@link #data} holds the secret bytes.
+ * </p>
  */
 @Builder
 @Data
 public class Secret {
 
     /**
-     * Version of the secret stored in Vault.
+     * Version of the secret as stored in Vault metadata.
      */
     public int version;
 


### PR DESCRIPTION
## Summary
- document SecretService#getSecret
- expand Secret data class javadocs

Key.java does not exist in the repository so no changes were made to that path.

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6885e4f53290832faba9963c3d52998d