### PR TITLE
Add missing Javadoc entries

### DIFF
--- a/src/main/java/org/saidone/model/MetadataKeys.java
+++ b/src/main/java/org/saidone/model/MetadataKeys.java
@@ -32,6 +32,10 @@ public interface MetadataKeys {
     String CONTENT_TYPE = "ct";
     /** Flag marking content as encrypted. */
     String ENCRYPTED = "enc";
+    /**
+     * Version identifier of the secret key that was used to encrypt
+     * the stored content.
+     */
     String KEY_VERSION = "kv";
     /** Original file name. */
     String FILENAME = "fn";

--- a/src/main/java/org/saidone/repository/EncryptedGridFsRepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/EncryptedGridFsRepositoryImpl.java
@@ -56,6 +56,7 @@ public class EncryptedGridFsRepositoryImpl extends GridFsRepositoryImpl {
      * @param gridFsTemplate   the GridFsTemplate for GridFS operations
      * @param gridFsOperations the GridFsOperations for GridFS operations
      * @param mongoTemplate    the MongoTemplate for MongoDB operations
+     * @param secretService    service providing encryption material
      * @param cryptoService    the CryptoService used for encryption and decryption
      */
     public EncryptedGridFsRepositoryImpl(

--- a/src/main/java/org/saidone/repository/EncryptedMongoNodeRepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/EncryptedMongoNodeRepositoryImpl.java
@@ -48,6 +48,7 @@ public class EncryptedMongoNodeRepositoryImpl extends MongoNodeRepositoryImpl {
      * Constructs an EncryptedMongoNodeRepositoryImpl with the given MongoOperations and CryptoService.
      *
      * @param mongoOperations the MongoDB operations instance
+     * @param secretService   service providing encryption material
      * @param cryptoService   the service used for encryption and decryption
      */
     public EncryptedMongoNodeRepositoryImpl(

--- a/src/main/java/org/saidone/repository/EncryptedS3RepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/EncryptedS3RepositoryImpl.java
@@ -56,6 +56,7 @@ public class EncryptedS3RepositoryImpl extends S3RepositoryImpl {
      * cryptographic service.
      *
      * @param s3Client      AWS S3 client
+     * @param secretService service providing encryption material
      * @param cryptoService service responsible for encryption and decryption
      */
     public EncryptedS3RepositoryImpl(S3Client s3Client, SecretService secretService, CryptoService cryptoService) {

--- a/src/main/java/org/saidone/service/crypto/AbstractCryptoService.java
+++ b/src/main/java/org/saidone/service/crypto/AbstractCryptoService.java
@@ -50,6 +50,7 @@ public abstract class AbstractCryptoService extends BaseComponent implements Cry
      * and derives a secret key accordingly. Supported KDF implementations include HKDF, Argon2,
      * and PBKDF2 (default).</p>
      *
+     * @param secret    the secret fetched from Vault
      * @param algorithm the name of the cryptographic algorithm for which the secret key is derived
      * @param salt      the salt value used in the key derivation process
      * @return a {@code Pair} containing the derived {@link javax.crypto.spec.SecretKeySpec} and an {@link Integer} representing the key version
@@ -65,6 +66,7 @@ public abstract class AbstractCryptoService extends BaseComponent implements Cry
     /**
      * Derives a secret key using the PBKDF2 algorithm.
      *
+     * @param secret    the secret fetched from Vault
      * @param algorithm the target algorithm of the resulting key
      * @param salt      the salt to use for key derivation
      * @return a pair containing the derived key and the version number
@@ -83,6 +85,7 @@ public abstract class AbstractCryptoService extends BaseComponent implements Cry
     /**
      * Derives a secret key using the HKDF key derivation function.
      *
+     * @param secret    the secret fetched from Vault
      * @param algorithm the target algorithm of the resulting key
      * @param salt      the salt value used for the HKDF extraction phase
      * @return a pair containing the derived key and the version number
@@ -100,6 +103,7 @@ public abstract class AbstractCryptoService extends BaseComponent implements Cry
     /**
      * Derives a secret key using the Argon2 key derivation function.
      *
+     * @param secret    the secret fetched from Vault
      * @param algorithm the target algorithm of the resulting key
      * @param salt      the salt to use for key derivation
      * @return a pair containing the derived key and the version number
@@ -196,9 +200,10 @@ public abstract class AbstractCryptoService extends BaseComponent implements Cry
     }
 
     /**
-     * Encrypts a plain text string and returns Base64 encoded result
+     * Encrypts a plain text string and returns a Base64 encoded result.
      *
-     * @param text The text to encrypt
+     * @param text   The text to encrypt
+     * @param secret secret material used to derive the encryption key
      * @return Base64 encoded encrypted text
      */
     public String encryptText(String text, Secret secret) {

--- a/src/main/java/org/saidone/service/crypto/BcCryptoServiceImpl.java
+++ b/src/main/java/org/saidone/service/crypto/BcCryptoServiceImpl.java
@@ -74,6 +74,11 @@ public class BcCryptoServiceImpl extends AbstractCryptoService implements Crypto
 
     private static final SecureRandom secureRandom = new SecureRandom();
 
+    /**
+     * Injects encryption configuration properties.
+     *
+     * @param properties resolved encryption configuration
+     */
     @Autowired
     public void configure(EncryptionConfig properties) {
         this.kdf = properties.getKdf();
@@ -93,6 +98,7 @@ public class BcCryptoServiceImpl extends AbstractCryptoService implements Crypto
      * The output stream format is: [key version][salt][nonce][encrypted data]
      *
      * @param inputStream The plaintext input data to be encrypted
+     * @param secret      secret material used to derive the encryption key
      * @return An InputStream containing concatenated salt, nonce and encrypted data
      * @throws RuntimeException if any error occurs during the encryption process
      */

--- a/src/main/java/org/saidone/service/crypto/CryptoService.java
+++ b/src/main/java/org/saidone/service/crypto/CryptoService.java
@@ -32,6 +32,7 @@ public interface CryptoService {
      * Encrypts the provided data stream.
      *
      * @param inputStream plaintext data to encrypt
+     * @param secret      secret material used to derive the encryption key
      * @return a stream containing the encrypted data
      */
     InputStream encrypt(InputStream inputStream, Secret secret);
@@ -47,7 +48,8 @@ public interface CryptoService {
     /**
      * Encrypts a text value and returns the Base64 encoded result.
      *
-     * @param text the text to encrypt
+     * @param text   the text to encrypt
+     * @param secret secret material used to derive the encryption key
      * @return encrypted text encoded in Base64
      */
     String encryptText(String text, Secret secret);

--- a/src/main/java/org/saidone/service/crypto/JcaCryptoServiceImpl.java
+++ b/src/main/java/org/saidone/service/crypto/JcaCryptoServiceImpl.java
@@ -66,6 +66,11 @@ public class JcaCryptoServiceImpl extends AbstractCryptoService implements Crypt
 
     private static final SecureRandom secureRandom = new SecureRandom();
 
+    /**
+     * Injects encryption configuration properties.
+     *
+     * @param properties resolved encryption configuration
+     */
     @Autowired
     public void configure(EncryptionConfig properties) {
         this.kdf = properties.getKdf();
@@ -85,6 +90,7 @@ public class JcaCryptoServiceImpl extends AbstractCryptoService implements Crypt
      * The output stream format is: [key version][salt][IV][encrypted data]
      *
      * @param inputStream The plaintext input data to be encrypted
+     * @param secret      secret material used to derive the encryption key
      * @return An InputStream containing concatenated salt, IV and encrypted data
      * @throws RuntimeException if any error occurs during the encryption process
      */


### PR DESCRIPTION
## Summary
- document `KEY_VERSION` constant
- complete constructor Javadocs for repository implementations
- document configuration injection in crypto service implementations
- add missing parameter details in CryptoService API
- document secret parameter in AbstractCryptoService helpers

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688722e76424832f8843a79b58cc34cb