### PR TITLE
Add javadocs for audit classes

### DIFF
--- a/src/main/java/org/saidone/component/AuditCollectionCreator.java
+++ b/src/main/java/org/saidone/component/AuditCollectionCreator.java
@@ -33,6 +33,14 @@ import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Creates and configures the MongoDB time series collection used to persist
+ * audit entries.
+ *
+ * <p>The collection is initialised on startup if it does not already exist
+ * and is configured with a TTL index so that documents expire automatically
+ * after {@link #ttlDays} days.</p>
+ */
 @RequiredArgsConstructor
 @Component
 @Slf4j

--- a/src/main/java/org/saidone/service/audit/AuditService.java
+++ b/src/main/java/org/saidone/service/audit/AuditService.java
@@ -30,6 +30,9 @@ import java.util.List;
  */
 public interface AuditService {
 
+    /**
+     * Name of the MongoDB collection used to store audit entries.
+     */
     String AUDIT_COLLECTION_NAME = "audit";
 
     /**

--- a/src/main/java/org/saidone/service/audit/AuditServiceImpl.java
+++ b/src/main/java/org/saidone/service/audit/AuditServiceImpl.java
@@ -42,6 +42,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AuditServiceImpl extends BaseComponent implements AuditService {
 
+    /**
+     * Template used to perform MongoDB operations.
+     */
     private final MongoTemplate mongoTemplate;
 
     /**


### PR DESCRIPTION
## Summary
- document the purpose of `AuditCollectionCreator`
- document the audit collection constant
- document the MongoDB template field

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688860814480832f8c38272c9fc2b044