### PR TITLE
Fix AuditWebFilter body content

### DIFF
--- a/src/main/java/org/saidone/service/audit/AuditWebFilter.java
+++ b/src/main/java/org/saidone/service/audit/AuditWebFilter.java
@@ -22,6 +22,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.http.HttpHeaders;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.http.server.reactive.ServerHttpRequestDecorator;
+import reactor.core.publisher.Flux;
 import org.jetbrains.annotations.NotNull;
 import org.saidone.component.BaseComponent;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -32,6 +36,8 @@ import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
 import reactor.core.publisher.Mono;
+
+import java.nio.charset.StandardCharsets;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -66,12 +72,31 @@ public class AuditWebFilter extends BaseComponent implements WebFilter {
     @NotNull
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
-        val requestEntry = createRequestAuditEntry(exchange.getRequest());
-        auditService.saveEntry(requestEntry);
-        return chain.filter(exchange).doFinally(signal -> {
-            val responseEntry = createResponseAuditEntry(requestEntry.getId(), exchange.getResponse());
-            auditService.saveEntry(responseEntry);
-        });
+        val bufferFactory = exchange.getResponse().bufferFactory();
+        return DataBufferUtils.join(exchange.getRequest().getBody())
+                .defaultIfEmpty(bufferFactory.allocateBuffer(0))
+                .flatMap(dataBuffer -> {
+                    byte[] bytes = new byte[dataBuffer.readableByteCount()];
+                    dataBuffer.read(bytes);
+                    DataBufferUtils.release(dataBuffer);
+                    String body = new String(bytes, StandardCharsets.UTF_8);
+
+                    val requestEntry = createRequestAuditEntry(exchange.getRequest(), body);
+                    auditService.saveEntry(requestEntry);
+
+                    ServerHttpRequest mutatedRequest = new ServerHttpRequestDecorator(exchange.getRequest()) {
+                        @Override
+                        public Flux<DataBuffer> getBody() {
+                            return Flux.defer(() -> Flux.just(bufferFactory.wrap(bytes)));
+                        }
+                    };
+                    val mutatedExchange = exchange.mutate().request(mutatedRequest).build();
+
+                    return chain.filter(mutatedExchange).doFinally(signal -> {
+                        val responseEntry = createResponseAuditEntry(requestEntry.getId(), mutatedExchange.getResponse());
+                        auditService.saveEntry(responseEntry);
+                    });
+                });
     }
 
     /**
@@ -80,7 +105,7 @@ public class AuditWebFilter extends BaseComponent implements WebFilter {
      * @param request the server request
      * @return populated audit entry for the request
      */
-    public static AuditEntry createRequestAuditEntry(ServerHttpRequest request) {
+    public static AuditEntry createRequestAuditEntry(ServerHttpRequest request, String body) {
         val metadata = new HashMap<String, Serializable>();
         metadata.put(AuditEntryKeys.METADATA_ID, request.getId());
         if (request.getRemoteAddress() != null) {
@@ -91,7 +116,7 @@ public class AuditWebFilter extends BaseComponent implements WebFilter {
         metadata.put(AuditEntryKeys.METADATA_METHOD, request.getMethod().toString());
         val entry = new AuditEntry();
         entry.setMetadata(metadata);
-        entry.setBody(request.getBody().toString());
+        entry.setBody(body);
         entry.setType(AuditEntryKeys.REQUEST);
         return entry;
     }


### PR DESCRIPTION
## Summary
- capture the request body so audit logs store the actual body content

## Testing
- `mvn -q test -o` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6889bc598c8c832fa21e1d5ca8e1e404