### PR TITLE
Improve repository Javadocs

### DIFF
--- a/src/main/java/org/saidone/model/NodeWrapper.java
+++ b/src/main/java/org/saidone/model/NodeWrapper.java
@@ -51,21 +51,32 @@ public class NodeWrapper {
 
     @Transient
     @JsonIgnore
+    /**
+     * Shared {@link ObjectMapper} used for serializing and deserializing
+     * the wrapped {@link Node}. It is configured via {@link #createObjectMapper()}.
+     */
     private static final ObjectMapper objectMapper = createObjectMapper();
 
     @Id
+    /** Identifier of the wrapped Alfresco node. */
     private String id;
     @Field("adt")
+    /** Timestamp when the node was archived. */
     private Instant archiveDate;
     @Field("res")
+    /** Flag indicating whether the node has been restored. */
     private boolean restored;
     @Field("enc")
+    /** Flag signalling that {@link #nodeJson} is encrypted. */
     private boolean encrypted;
     @Field("kv")
+    /** Version of the key used to encrypt {@link #nodeJson}. */
     private int keyVersion;
     @Field("nj")
+    /** JSON representation of the node. May be encrypted. */
     private String nodeJson;
     @Field("ntx")
+    /** Transaction id returned from notarization, if any. */
     private String notarizationTxId;
 
     /**
@@ -107,6 +118,8 @@ public class NodeWrapper {
      * Creates a preconfigured {@link ObjectMapper} instance used to
      * serialize and deserialize nodes. Dates are written in ISO format and
      * unknown properties are ignored when reading.
+     *
+     * @return a fully configured mapper for node (de)serialization
      */
     private static ObjectMapper createObjectMapper() {
         val mapper = new ObjectMapper();

--- a/src/main/java/org/saidone/repository/EncryptedGridFsRepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/EncryptedGridFsRepositoryImpl.java
@@ -47,7 +47,9 @@ import java.util.Map;
 )
 public class EncryptedGridFsRepositoryImpl extends GridFsRepositoryImpl {
 
+    /** Service providing encryption secrets for content. */
     private final SecretService secretService;
+    /** Component performing the actual encryption/decryption. */
     private final CryptoService cryptoService;
 
     /**

--- a/src/main/java/org/saidone/repository/EncryptedMongoNodeRepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/EncryptedMongoNodeRepositoryImpl.java
@@ -41,7 +41,9 @@ import java.util.Optional;
         havingValue = "true")
 public class EncryptedMongoNodeRepositoryImpl extends MongoNodeRepositoryImpl {
 
+    /** Provides encryption material for node metadata. */
     private final SecretService secretService;
+    /** Service used to encrypt and decrypt node JSON. */
     private final CryptoService cryptoService;
 
     /**

--- a/src/main/java/org/saidone/repository/EncryptedS3RepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/EncryptedS3RepositoryImpl.java
@@ -47,6 +47,7 @@ import java.util.HashMap;
 @Slf4j
 public class EncryptedS3RepositoryImpl extends S3RepositoryImpl {
 
+    /** Provides encryption keys used for securing S3 objects. */
     private final SecretService secretService;
     /**
      * Service used to perform stream encryption and decryption.


### PR DESCRIPTION
## Summary
- expand `NodeWrapper` javadocs
- document services in encrypted repository classes

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688b0644eee4832f87cd70d1d3ff4bbb