### PR TITLE
docs: improve Javadoc for node service components

### DIFF
--- a/src/main/java/org/saidone/job/NodeNotarizationJob.java
+++ b/src/main/java/org/saidone/job/NodeNotarizationJob.java
@@ -47,7 +47,10 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class NodeNotarizationJob extends BaseComponent {
 
+    /** Service providing access to vault-stored nodes. */
     private final NodeService nodeService;
+
+    /** Blockchain service responsible for notarising node checksums. */
     private final EthereumService ethereumService;
 
     /**
@@ -60,6 +63,7 @@ public class NodeNotarizationJob extends BaseComponent {
 
     /**
      * Scheduled entry point triggered according to the configured cron expression.
+     * Delegates execution to {@link #doNotarize()}.
      */
     @Scheduled(cron = "${application.notarization-job.cron-expression}")
     void notarize() {

--- a/src/main/java/org/saidone/repository/MongoNodeRepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/MongoNodeRepositoryImpl.java
@@ -183,7 +183,12 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
         return mongoOperations.find(query, NodeWrapper.class);
     }
 
-    // find by encryption key version
+    /**
+     * Retrieves node wrappers by encryption key version.
+     *
+     * @param kv the encryption key version to filter by
+     * @return list of nodes encrypted with the specified key version
+     */
     public List<NodeWrapper> findByKv(String kv) {
         val query = new Query(Criteria.where("kv").is(kv));
         return mongoOperations.find(query, NodeWrapper.class);

--- a/src/main/java/org/saidone/service/MongoNodeService.java
+++ b/src/main/java/org/saidone/service/MongoNodeService.java
@@ -37,6 +37,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class MongoNodeService extends BaseComponent implements NodeService {
 
+    /** Repository used for persisting and retrieving node metadata. */
     private final MongoNodeRepositoryImpl mongoNodeRepository;
 
     /**
@@ -80,7 +81,7 @@ public class MongoNodeService extends BaseComponent implements NodeService {
      */
     @Override
     public Iterable<NodeWrapper> findByKv(String kv) {
-        return mongoNodeRepository.findByNtx(kv);
+        return mongoNodeRepository.findByKv(kv);
     }
 
     /**

--- a/src/main/java/org/saidone/service/NodeService.java
+++ b/src/main/java/org/saidone/service/NodeService.java
@@ -52,8 +52,13 @@ public interface NodeService {
      */
     Iterable<NodeWrapper> findByNtx(String ntx);
 
-    // find by encryption key version
-    Iterable<NodeWrapper> findByKv(String txId);
+    /**
+     * Retrieves all node wrappers associated with the specified encryption key version.
+     *
+     * @param kv the encryption key version to filter by
+     * @return iterable collection of {@link NodeWrapper}
+     */
+    Iterable<NodeWrapper> findByKv(String kv);
 
     /**
      * Retrieves all stored node wrappers.


### PR DESCRIPTION
## Summary
- document node and blockchain service dependencies within NodeNotarizationJob
- document encryption key version lookups in service and repository layers
- clarify MongoNodeService persistence repository and fix findByKv delegation

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68904deb6ca4832fbc64270d97b0b3d6