### PR TITLE
Improve javadoc for services and repository

### DIFF
--- a/src/main/java/org/saidone/repository/MongoNodeRepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/MongoNodeRepositoryImpl.java
@@ -66,6 +66,9 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
 
     private final MongoOperations mongoOperations;
 
+    /**
+     * {@inheritDoc}
+     */
     @PostConstruct
     @Override
     public void init() {
@@ -78,6 +81,7 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
         }
     }
 
+    /** {@inheritDoc} */
     @Override
     @NonNull
     public <S extends NodeWrapper> S insert(@NonNull S entity) {
@@ -85,6 +89,7 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
         return entity;
     }
 
+    /** {@inheritDoc} */
     @Override
     @NonNull
     public <S extends NodeWrapper> List<S> insert(@NonNull Iterable<S> entities) {
@@ -95,6 +100,7 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
         return result;
     }
 
+    /** {@inheritDoc} */
     @Override
     @NonNull
     public <S extends NodeWrapper> S save(@NonNull S entity) {
@@ -102,6 +108,7 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
         return entity;
     }
 
+    /** {@inheritDoc} */
     @Override
     @NonNull
     public <S extends NodeWrapper> List<S> saveAll(@NonNull Iterable<S> entities) {
@@ -112,6 +119,7 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
         return result;
     }
 
+    /** {@inheritDoc} */
     @Override
     @NonNull
     public <S extends NodeWrapper> Optional<S> findOne(@NonNull Example<S> example) {
@@ -120,6 +128,7 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
                 example.getProbeType()));
     }
 
+    /** {@inheritDoc} */
     @Override
     @NonNull
     public <S extends NodeWrapper> List<S> findAll(@NonNull Example<S> example) {
@@ -128,6 +137,7 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
                 example.getProbeType());
     }
 
+    /** {@inheritDoc} */
     @Override
     @NonNull
     public <S extends NodeWrapper> List<S> findAll(@NonNull Example<S> example, @NonNull Sort sort) {
@@ -136,6 +146,7 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
                 example.getProbeType());
     }
 
+    /** {@inheritDoc} */
     @Override
     @NonNull
     public <S extends NodeWrapper> Page<S> findAll(@NonNull Example<S> example, @NonNull Pageable pageable) {
@@ -146,6 +157,11 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
         return new PageImpl<>(content, pageable, count);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @throws UnsupportedOperationException always thrown as this method is not implemented
+     */
     @Override
     public <S extends NodeWrapper, R> @NonNull R findBy(@NonNull Example<S> example, @NonNull Function<FluentQuery.FetchableFluentQuery<S>, R> queryFunction) {
         val methodSignature = StackWalker.getInstance()
@@ -155,17 +171,20 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
         throw new UnsupportedOperationException(String.format("Method %s is not implemented in this version of the repository", methodSignature));
     }
 
+    /** {@inheritDoc} */
     @Override
     @NonNull
     public Optional<NodeWrapper> findById(@NonNull String id) {
         return Optional.ofNullable(mongoOperations.findById(id, NodeWrapper.class));
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean existsById(@NonNull String id) {
         return mongoOperations.exists(Query.query(Criteria.where("_id").is(id)), NodeWrapper.class);
     }
 
+    /** {@inheritDoc} */
     @Override
     @NonNull
     public List<NodeWrapper> findAll() {
@@ -195,6 +214,7 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
         return mongoOperations.find(query, NodeWrapper.class);
     }
 
+    /** {@inheritDoc} */
     @Override
     @NonNull
     public List<NodeWrapper> findAllById(@NonNull Iterable<String> ids) {
@@ -202,28 +222,33 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
         return mongoOperations.find(query, NodeWrapper.class);
     }
 
+    /** {@inheritDoc} */
     @Override
     public long count() {
         return mongoOperations.count(new Query(), NodeWrapper.class);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void deleteById(@NonNull String id) {
         val query = new Query(Criteria.where("_id").is(id));
         mongoOperations.remove(query, NodeWrapper.class);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void delete(@NonNull NodeWrapper entity) {
         mongoOperations.remove(entity);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void deleteAllById(@NonNull Iterable<? extends String> ids) {
         val query = new Query(Criteria.where("_id").in(ids));
         mongoOperations.remove(query, NodeWrapper.class);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void deleteAll(@NonNull Iterable<? extends NodeWrapper> entities) {
         for (val entity : entities) {
@@ -231,17 +256,20 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
         }
     }
 
+    /** {@inheritDoc} */
     @Override
     public void deleteAll() {
         mongoOperations.remove(new Query(), NodeWrapper.class);
     }
 
+    /** {@inheritDoc} */
     @Override
     @NonNull
     public List<NodeWrapper> findAll(@NonNull Sort sort) {
         return mongoOperations.find(new Query().with(sort), NodeWrapper.class);
     }
 
+    /** {@inheritDoc} */
     @Override
     @NonNull
     public Page<NodeWrapper> findAll(@NonNull Pageable pageable) {
@@ -253,11 +281,13 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
         return new PageImpl<>(content, pageable, count);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <S extends NodeWrapper> long count(@NonNull Example<S> example) {
         return mongoOperations.count(Query.query(Criteria.byExample(example)), example.getProbeType());
     }
 
+    /** {@inheritDoc} */
     @Override
     public <S extends NodeWrapper> boolean exists(@NonNull Example<S> example) {
         return mongoOperations.exists(Query.query(Criteria.byExample(example)), example.getProbeType());

--- a/src/main/java/org/saidone/service/MongoNodeService.java
+++ b/src/main/java/org/saidone/service/MongoNodeService.java
@@ -40,11 +40,7 @@ public class MongoNodeService extends BaseComponent implements NodeService {
     /** Repository used for persisting and retrieving node metadata. */
     private final MongoNodeRepositoryImpl mongoNodeRepository;
 
-    /**
-     * Saves the given node wrapper to the repository.
-     *
-     * @param nodeWrapper node metadata to persist
-     */
+    /** {@inheritDoc} */
     @Override
     @SneakyThrows
     public void save(NodeWrapper nodeWrapper) {

--- a/src/main/java/org/saidone/service/NodeService.java
+++ b/src/main/java/org/saidone/service/NodeService.java
@@ -18,6 +18,7 @@
 
 package org.saidone.service;
 
+import org.saidone.exception.NodeNotFoundOnVaultException;
 import org.saidone.model.NodeWrapper;
 
 /**
@@ -39,6 +40,7 @@ public interface NodeService {
      *
      * @param nodeId the Alfresco node identifier
      * @return the stored {@link NodeWrapper}
+     * @throws NodeNotFoundOnVaultException if the node does not exist in the vault
      */
     NodeWrapper findById(String nodeId);
 

--- a/src/main/java/org/saidone/service/crypto/KeyService.java
+++ b/src/main/java/org/saidone/service/crypto/KeyService.java
@@ -18,12 +18,32 @@
 
 package org.saidone.service.crypto;
 
+/**
+ * Service responsible for managing encryption keys used to protect nodes in the vault.
+ * Implementations typically handle key rotation and re-encryption of persisted data.
+ */
 public interface KeyService {
 
+    /**
+     * Re-encrypts the node identified by the given ID using the latest available key version.
+     *
+     * @param nodeId the Alfresco node identifier
+     */
     void updateKey(String nodeId);
 
+    /**
+     * Re-encrypts all nodes currently protected with the specified key version to the latest version.
+     *
+     * @param sourceVersion the encryption key version currently used by the nodes to update
+     */
     void updateKeys(int sourceVersion);
 
+    /**
+     * Re-encrypts all nodes from the given source key version to the desired target key version.
+     *
+     * @param sourceVersion the encryption key version from which nodes will be re-encrypted
+     * @param targetVersion the target encryption key version to apply
+     */
     void updateKeys(int sourceVersion, int targetVersion);
 
 }

--- a/src/main/java/org/saidone/service/crypto/KeyServiceImpl.java
+++ b/src/main/java/org/saidone/service/crypto/KeyServiceImpl.java
@@ -23,22 +23,29 @@ import lombok.val;
 import org.saidone.service.NodeService;
 import org.springframework.stereotype.Service;
 
+/**
+ * Default {@link KeyService} implementation that delegates node retrieval to a {@link NodeService}.
+ * The actual re-encryption logic is currently left unimplemented and will be provided in future iterations.
+ */
 @RequiredArgsConstructor
 @Service
 public class KeyServiceImpl implements KeyService {
 
     private final NodeService nodeService;
 
+    /** {@inheritDoc} */
     @Override
     public void updateKey(String nodeId) {
 
     }
 
+    /** {@inheritDoc} */
     @Override
     public void updateKeys(int sourceVersion) {
         val nodes = nodeService.findByKv(sourceVersion);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void updateKeys(int sourceVersion, int targetVersion) {
 


### PR DESCRIPTION
## Summary
- document NodeService's findById and reference NodeNotFoundOnVaultException
- expand KeyService API with class and method Javadoc
- propagate inherited Javadoc across Mongo repository and service implementations

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_689052f5611c832f9486e084b420292f