### PR TITLE
Improve javadoc for secret and key services

### DIFF
--- a/src/main/java/org/saidone/service/SecretService.java
+++ b/src/main/java/org/saidone/service/SecretService.java
@@ -76,8 +76,8 @@ public class SecretService extends BaseComponent {
      * Retrieves the latest version of the secret from Vault.
      *
      * <p>This is a convenience method that delegates to
-     * {@link #getSecret(Integer)} with a {@code null} version</p>
-     * to fetch the most recent secret value.</p>
+     * {@link #getSecret(Integer)} with a {@code null} version to fetch the most
+     * recent secret value.</p>
      *
      * @return the secret containing the raw bytes and version information
      * @throws RuntimeException if the secret cannot be retrieved
@@ -93,9 +93,11 @@ public class SecretService extends BaseComponent {
     /**
      * Retrieves the secret from Vault for the specified version.
      *
-     * @param version the version of the secret to retrieve; if null, retrieves the latest version
-     * @return a Pair containing the secret bytes and the version number
-     * @throws RuntimeException if unable to retrieve the secret or if an error occurs during retrieval
+     * @param version the version of the secret to retrieve; if {@code null},
+     *                retrieves the latest version
+     * @return a {@link Secret} containing the secret bytes and the version number
+     * @throws RuntimeException if unable to retrieve the secret or if an error
+     *                          occurs during retrieval
      */
     public Secret getSecret(Integer version) {
         try {
@@ -110,7 +112,7 @@ public class SecretService extends BaseComponent {
      *
      * @param version version of the secret to retrieve; {@code null} for the
      *                latest version
-     * @return a future yielding the secret data and version
+     * @return a {@link CompletableFuture} yielding the secret data and version
      */
     private CompletableFuture<Secret> getSecretAsync(Integer version) {
         return CompletableFuture.supplyAsync(() -> {

--- a/src/main/java/org/saidone/service/crypto/KeyService.java
+++ b/src/main/java/org/saidone/service/crypto/KeyService.java
@@ -19,22 +19,26 @@
 package org.saidone.service.crypto;
 
 /**
- * Service responsible for managing encryption keys used to protect nodes in the vault.
- * Implementations typically handle key rotation and re-encryption of persisted data.
+ * Service responsible for managing encryption keys used to protect nodes in the
+ * vault. Implementations typically handle key rotation and re-encryption of
+ * persisted data.
  */
 public interface KeyService {
 
     /**
-     * Re-encrypts the node identified by the given ID using the latest available key version.
+     * Re-encrypts the node identified by the given ID using the latest available
+     * key version and persists the updated node.
      *
      * @param nodeId the Alfresco node identifier
      */
     void updateKey(String nodeId);
 
     /**
-     * Re-encrypts all nodes currently protected with the specified key version to the latest version.
+     * Re-encrypts all nodes currently protected with the specified key version
+     * to the latest version.
      *
-     * @param sourceVersion the encryption key version currently used by the nodes to update
+     * @param sourceVersion the encryption key version currently used by the nodes
+     *                      that should be updated
      */
     void updateKeys(int sourceVersion);
 

--- a/src/main/java/org/saidone/service/crypto/KeyServiceImpl.java
+++ b/src/main/java/org/saidone/service/crypto/KeyServiceImpl.java
@@ -26,8 +26,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Service;
 
 /**
- * Default {@link KeyService} implementation that delegates node retrieval to a {@link NodeService}.
- * The actual re-encryption logic is currently left unimplemented and will be provided in future iterations.
+ * Default {@link KeyService} implementation that re-encrypts node content by
+ * delegating node retrieval to {@link NodeService} and content handling to
+ * {@link ContentService}.
  */
 @RequiredArgsConstructor
 @Service
@@ -38,17 +39,29 @@ public class KeyServiceImpl implements KeyService {
     private final ContentService contentService;
 
     /**
-     * {@inheritDoc}
+     * Re-encrypts the node identified by the given ID using the latest key
+     * version.
+     *
+     * <p>The node metadata is loaded from the {@link NodeService}, its content
+     * is archived using the {@link ContentService}, and the updated node is
+     * persisted.</p>
+     *
+     * @param nodeId the Alfresco node identifier
      */
     @Override
     public void updateKey(String nodeId) {
         val nodeWrapper = nodeService.findById(nodeId);
-       contentService.archiveNodeContent(nodeWrapper.getNode(), contentService.getNodeContent(nodeId).getContentStream());
-       nodeService.save(nodeWrapper);
+        contentService.archiveNodeContent(nodeWrapper.getNode(),
+                contentService.getNodeContent(nodeId).getContentStream());
+        nodeService.save(nodeWrapper);
     }
 
     /**
-     * {@inheritDoc}
+     * Re-encrypts all nodes currently protected with the specified key version
+     * by delegating each node to {@link #updateKey(String)}.
+     *
+     * @param sourceVersion the key version currently used by nodes that should
+     *                      be updated
      */
     @Override
     public void updateKeys(int sourceVersion) {


### PR DESCRIPTION
## Summary
- refine secret retrieval javadocs
- document key rotation service API
- expand implementation details for key service

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891ac5f9f54832f83cbc8c596e1b4ca