### PR TITLE
Use TaskExecutor for Vault API async tasks

### DIFF
--- a/src/main/java/org/saidone/config/AsyncConfig.java
+++ b/src/main/java/org/saidone/config/AsyncConfig.java
@@ -1,0 +1,26 @@
+package org.saidone.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/**
+ * Configuration for asynchronous task execution.
+ */
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean
+    public TaskExecutor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("vault-async-");
+        executor.initialize();
+        return executor;
+    }
+}


### PR DESCRIPTION
## Summary
- create AsyncConfig providing a ThreadPoolTaskExecutor bean
- run notarization and key update tasks on the managed executor with logging and exception handling

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689481307c8c832f9806cae4b2713f49