### PR TITLE
fix: improve javadoc formatting

### DIFF
--- a/src/main/java/org/saidone/model/NodeWrapper.java
+++ b/src/main/java/org/saidone/model/NodeWrapper.java
@@ -49,34 +49,40 @@ import java.time.Instant;
 @Slf4j
 public class NodeWrapper {
 
-    @Transient
-    @JsonIgnore
     /**
      * Shared {@link ObjectMapper} used for serializing and deserializing
      * the wrapped {@link Node}. It is configured via {@link #createObjectMapper()}.
      */
+    @Transient
+    @JsonIgnore
     private static final ObjectMapper objectMapper = createObjectMapper();
 
-    @Id
     /** Identifier of the wrapped Alfresco node. */
+    @Id
     private String id;
-    @Field("adt")
+
     /** Timestamp when the node was archived. */
+    @Field("adt")
     private Instant archiveDate;
-    @Field("res")
+
     /** Flag indicating whether the node has been restored. */
+    @Field("res")
     private boolean restored;
-    @Field("enc")
+
     /** Flag signalling that {@link #nodeJson} is encrypted. */
+    @Field("enc")
     private boolean encrypted;
-    @Field("kv")
+
     /** Version of the key used to encrypt {@link #nodeJson}. */
+    @Field("kv")
     private int keyVersion;
-    @Field("nj")
+
     /** JSON representation of the node. May be encrypted. */
+    @Field("nj")
     private String nodeJson;
-    @Field("ntx")
+
     /** Transaction id returned from notarization, if any. */
+    @Field("ntx")
     private String notarizationTxId;
 
     /**

--- a/src/main/java/org/saidone/utils/ResourceFileUtils.java
+++ b/src/main/java/org/saidone/utils/ResourceFileUtils.java
@@ -48,6 +48,7 @@ public class ResourceFileUtils {
      *
      * @param resourcePath the path to the resource, either absolute path in the filesystem or a classpath resource
      * @return the {@link File} object representing the resource
+     * @throws IOException if an I/O error occurs while accessing the resource
      */
     public File getFileFromResource(String resourcePath) throws IOException {
         return getFileFromResource(resourcePath, null);


### PR DESCRIPTION
## Summary
- ensure NodeWrapper field Javadocs precede annotations
- document IOException thrown by ResourceFileUtils#getFileFromResource

## Testing
- `mvn test` *(fails: Non-resolvable parent POM for org.saidone:alfresco-node-vault:0.0.4-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68959baa03d0832fa2e8689522eb3bd0