### PR TITLE
feat: add archive date search endpoint

### DIFF
--- a/src/main/java/org/saidone/repository/MongoNodeRepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/MongoNodeRepositoryImpl.java
@@ -237,6 +237,31 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
     }
 
     /**
+     * Retrieves node wrappers archived within the specified date range using pagination.
+     *
+     * @param from     lower bound of the archive date range, inclusive. {@code null} for no lower bound.
+     * @param to       upper bound of the archive date range, inclusive. {@code null} for no upper bound.
+     * @param pageable pagination information
+     * @return page of matching nodes
+     */
+    public Page<NodeWrapper> findByArchiveDateRange(Instant from, Instant to, Pageable pageable) {
+        Criteria criteria;
+        if (from != null && to != null) {
+            criteria = Criteria.where("adt").gte(from).lte(to);
+        } else if (from != null) {
+            criteria = Criteria.where("adt").gte(from);
+        } else if (to != null) {
+            criteria = Criteria.where("adt").lte(to);
+        } else {
+            return findAll(pageable);
+        }
+        long count = mongoOperations.count(new Query(criteria), NodeWrapper.class);
+        val query = new Query(criteria).with(pageable);
+        val content = mongoOperations.find(query, NodeWrapper.class);
+        return new PageImpl<>(content, pageable, count);
+    }
+
+    /**
      * Retrieves node wrappers by notarization transaction ID. A {@code null} value
      * matches nodes without a transaction ID.
      *

--- a/src/main/java/org/saidone/service/MongoNodeService.java
+++ b/src/main/java/org/saidone/service/MongoNodeService.java
@@ -25,6 +25,8 @@ import org.saidone.component.BaseComponent;
 import org.saidone.exception.NodeNotFoundOnVaultException;
 import org.saidone.model.NodeWrapper;
 import org.saidone.repository.MongoNodeRepositoryImpl;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -72,6 +74,14 @@ public class MongoNodeService extends BaseComponent implements NodeService {
     @Override
     public Iterable<NodeWrapper> findByArchiveDateRange(Instant from, Instant to) {
         return mongoNodeRepository.findByArchiveDateRange(from, to);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Page<NodeWrapper> findByArchiveDateRange(Instant from, Instant to, Pageable pageable) {
+        return mongoNodeRepository.findByArchiveDateRange(from, to, pageable);
     }
 
     /**

--- a/src/main/java/org/saidone/service/NodeService.java
+++ b/src/main/java/org/saidone/service/NodeService.java
@@ -20,6 +20,8 @@ package org.saidone.service;
 
 import org.saidone.exception.NodeNotFoundOnVaultException;
 import org.saidone.model.NodeWrapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.Instant;
 
@@ -56,6 +58,18 @@ public interface NodeService {
      * @return iterable collection of {@link NodeWrapper}
      */
     Iterable<NodeWrapper> findByArchiveDateRange(Instant from, Instant to);
+
+    /**
+     * Retrieves node wrappers archived within the specified date range using pagination.
+     * Both bounds are inclusive. Passing {@code null} for one of the parameters will
+     * make the range open-ended on that side.
+     *
+     * @param from     the lower bound of the archive date range, inclusive
+     * @param to       the upper bound of the archive date range, inclusive
+     * @param pageable pagination information
+     * @return page of {@link NodeWrapper}
+     */
+    Page<NodeWrapper> findByArchiveDateRange(Instant from, Instant to, Pageable pageable);
 
     /**
      * Retrieves all node wrappers having the given notarization transaction ID.

--- a/src/test/java/org/saidone/test/VaultApiControllerTests.java
+++ b/src/test/java/org/saidone/test/VaultApiControllerTests.java
@@ -121,6 +121,31 @@ class VaultApiControllerTests extends BaseTest {
     }
 
     @Test
+    @Order(20)
+    @SneakyThrows
+    void searchNodesByArchiveDateTest() {
+        val nodeId1 = createNode().getId();
+        Thread.sleep(1000);
+        val nodeId2 = createNode().getId();
+        vaultService.archiveNode(nodeId1);
+        Thread.sleep(1000);
+        vaultService.archiveNode(nodeId2);
+
+        performRequestAndProcess(HttpMethod.GET, "/api/vault/search?page={page}&size={size}", new Object[]{0, 1},
+                null, 200, String.class, body -> {
+                    assertTrue(body.contains(nodeId1));
+                    assertFalse(body.contains(nodeId2));
+                    assertTrue(body.contains("\"totalElements\":2"));
+                });
+
+        performRequestAndProcess(HttpMethod.GET, "/api/vault/search?page={page}&size={size}", new Object[]{1, 1},
+                null, 200, String.class, body -> {
+                    assertTrue(body.contains(nodeId2));
+                    assertFalse(body.contains(nodeId1));
+                });
+    }
+
+    @Test
     @Order(30)
     @SneakyThrows
     void restoreNodeTest() {


### PR DESCRIPTION
## Summary
- support paginated archive-date queries in node service and repository
- add `/api/vault/search` endpoint for paginated archive-date search
- test search pagination

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_6896e5b3c9ec832f8ef938c181782b54