### PR TITLE
fix: correct audit service javadocs

### DIFF
--- a/src/main/java/org/saidone/service/audit/AuditService.java
+++ b/src/main/java/org/saidone/service/audit/AuditService.java
@@ -47,11 +47,10 @@ public interface AuditService {
     /**
      * Retrieve stored audit entries.
      *
-     * @param type      optional entry type to filter by
-     * @param from      lower bound of the timestamp range (inclusive)
-     * @param to        upper bound of the timestamp range (inclusive)
-     * @param maxItems  maximum number of items to return
-     * @param skipCount number of items to skip (for pagination)
+     * @param type     optional entry type to filter by
+     * @param from     lower bound of the timestamp range (inclusive)
+     * @param to       upper bound of the timestamp range (inclusive)
+     * @param pageable pagination information such as page number and size
      * @return list of matching audit entries ordered by timestamp descending
      */
     List<AuditEntry> findEntries(String type, Instant from, Instant to, Pageable pageable);

--- a/src/main/java/org/saidone/service/audit/AuditServiceImpl.java
+++ b/src/main/java/org/saidone/service/audit/AuditServiceImpl.java
@@ -59,11 +59,10 @@ public class AuditServiceImpl extends BaseComponent implements AuditService {
     /**
      * Retrieve audit entries filtered by type and timestamp.
      *
-     * @param type      optional entry type to filter by
-     * @param from      lower bound of the timestamp range (inclusive)
-     * @param to        upper bound of the timestamp range (inclusive)
-     * @param maxItems  maximum number of items to return
-     * @param skipCount number of items to skip (for pagination)
+     * @param type     optional entry type to filter by
+     * @param from     lower bound of the timestamp range (inclusive)
+     * @param to       upper bound of the timestamp range (inclusive)
+     * @param pageable pagination information such as page number and size
      * @return list of matching audit entries ordered by timestamp descending
      */
     @Override


### PR DESCRIPTION
## Summary
- clarify audit service interface Javadoc
- correct Javadoc for audit query implementation

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68998eac7ee0832f90d90f14d7326cb0