### PR TITLE
feat: add sort to archive date range queries

### DIFF
--- a/src/main/java/org/saidone/repository/EncryptedMongoNodeRepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/EncryptedMongoNodeRepositoryImpl.java
@@ -26,6 +26,7 @@ import org.saidone.service.crypto.CryptoService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.stereotype.Repository;
 
@@ -99,6 +100,14 @@ public class EncryptedMongoNodeRepositoryImpl extends MongoNodeRepositoryImpl {
     @Override
     public List<NodeWrapper> findByArchiveDateRange(Instant from, Instant to) {
         val result = super.findByArchiveDateRange(from, to);
+        result.forEach(this::decryptNode);
+        return result;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<NodeWrapper> findByArchiveDateRange(Instant from, Instant to, Sort sort) {
+        val result = super.findByArchiveDateRange(from, to, sort);
         result.forEach(this::decryptNode);
         return result;
     }

--- a/src/main/java/org/saidone/repository/MongoNodeRepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/MongoNodeRepositoryImpl.java
@@ -227,6 +227,19 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
      * @return list of matching nodes
      */
     public List<NodeWrapper> findByArchiveDateRange(Instant from, Instant to) {
+        return findByArchiveDateRange(from, to, Sort.by(Sort.Direction.ASC, "adt"));
+    }
+
+    /**
+     * Retrieves node wrappers whose archive date falls within the specified range
+     * applying the provided {@link Sort} order.
+     *
+     * @param from lower bound of the archive date range, inclusive. {@code null} for no lower bound.
+     * @param to   upper bound of the archive date range, inclusive. {@code null} for no upper bound.
+     * @param sort sort directive, defaults to ascending {@code adt} if {@code null}
+     * @return list of matching nodes
+     */
+    public List<NodeWrapper> findByArchiveDateRange(Instant from, Instant to, Sort sort) {
         Criteria criteria;
         if (from != null && to != null) {
             criteria = Criteria.where("adt").gte(from).lte(to);
@@ -235,9 +248,9 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
         } else if (to != null) {
             criteria = Criteria.where("adt").lte(to);
         } else {
-            return findAll();
+            return findAll(sort != null ? sort : Sort.by(Sort.Direction.ASC, "adt"));
         }
-        val query = new Query(criteria);
+        val query = new Query(criteria).with(sort != null ? sort : Sort.by(Sort.Direction.ASC, "adt"));
         return mongoOperations.find(query, NodeWrapper.class);
     }
 
@@ -260,10 +273,14 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
         } else {
             return findAll(pageable);
         }
+        Pageable sortedPageable = pageable;
+        if (pageable.getSort().isUnsorted()) {
+            sortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Sort.Direction.ASC, "adt"));
+        }
         long count = mongoOperations.count(new Query(criteria), NodeWrapper.class);
-        val query = new Query(criteria).with(pageable);
+        val query = new Query(criteria).with(sortedPageable);
         val content = mongoOperations.find(query, NodeWrapper.class);
-        return new PageImpl<>(content, pageable, count);
+        return new PageImpl<>(content, sortedPageable, count);
     }
 
     /**


### PR DESCRIPTION
## Summary
- make archive date range queries accept custom sorting and default to ascending archive date
- ensure encrypted repository decrypts results for sortable queries

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_689ad2562d9c832f848a2af3a2d1a424