### PR TITLE
feat: allow sorting when searching nodes

### DIFF
--- a/src/main/java/org/saidone/controller/VaultApiController.java
+++ b/src/main/java/org/saidone/controller/VaultApiController.java
@@ -116,7 +116,9 @@ public class VaultApiController {
                     @Parameter(name = "from", description = "Start archive date (ISO-8601)", in = ParameterIn.QUERY),
                     @Parameter(name = "to", description = "End archive date (ISO-8601)", in = ParameterIn.QUERY),
                     @Parameter(name = "page", description = "Page number", in = ParameterIn.QUERY),
-                    @Parameter(name = "size", description = "Page size", in = ParameterIn.QUERY)
+                    @Parameter(name = "size", description = "Page size", in = ParameterIn.QUERY),
+                    @Parameter(name = "sort", description = "Field to sort by", in = ParameterIn.QUERY),
+                    @Parameter(name = "dir", description = "Sort direction (ASC or DESC)", in = ParameterIn.QUERY)
             },
             responses = {
                     @ApiResponse(responseCode = "200", description = "Nodes retrieved",
@@ -131,13 +133,15 @@ public class VaultApiController {
             @RequestParam(required = false) Instant from,
             @RequestParam(required = false) Instant to,
             @RequestParam(required = false, defaultValue = "0") int page,
-            @RequestParam(required = false, defaultValue = "20") int size) {
+            @RequestParam(required = false, defaultValue = "20") int size,
+            @RequestParam(required = false, defaultValue = "archiveDate") String sort,
+            @RequestParam(required = false, defaultValue = "ASC") Sort.Direction dir) {
 
         if (!authenticationService.isAuthorized(auth)) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        val pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "archiveDate"));
+        val pageable = PageRequest.of(page, size, Sort.by(dir, sort));
         val result = nodeService.findByArchiveDateRange(from, to, pageable)
                 .map(nodeWrapper -> new Entry(nodeWrapper.getNode()));
         return ResponseEntity.ok(result);

--- a/src/main/java/org/saidone/service/MongoNodeService.java
+++ b/src/main/java/org/saidone/service/MongoNodeService.java
@@ -27,6 +27,7 @@ import org.saidone.model.NodeWrapper;
 import org.saidone.repository.MongoNodeRepositoryImpl;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -74,6 +75,14 @@ public class MongoNodeService extends BaseComponent implements NodeService {
     @Override
     public Iterable<NodeWrapper> findByArchiveDateRange(Instant from, Instant to) {
         return mongoNodeRepository.findByArchiveDateRange(from, to);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Iterable<NodeWrapper> findByArchiveDateRange(Instant from, Instant to, Sort sort) {
+        return mongoNodeRepository.findByArchiveDateRange(from, to, sort);
     }
 
     /**

--- a/src/main/java/org/saidone/service/NodeService.java
+++ b/src/main/java/org/saidone/service/NodeService.java
@@ -22,6 +22,7 @@ import org.saidone.exception.NodeNotFoundOnVaultException;
 import org.saidone.model.NodeWrapper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.time.Instant;
 
@@ -58,6 +59,19 @@ public interface NodeService {
      * @return iterable collection of {@link NodeWrapper}
      */
     Iterable<NodeWrapper> findByArchiveDateRange(Instant from, Instant to);
+
+    /**
+     * Retrieves node wrappers archived within the specified date range applying the
+     * provided {@link Sort} order. Both bounds are inclusive. Passing
+     * {@code null} for one of the parameters will make the range open-ended on
+     * that side.
+     *
+     * @param from the lower bound of the archive date range, inclusive
+     * @param to   the upper bound of the archive date range, inclusive
+     * @param sort sort directive to apply
+     * @return iterable collection of {@link NodeWrapper}
+     */
+    Iterable<NodeWrapper> findByArchiveDateRange(Instant from, Instant to, Sort sort);
 
     /**
      * Retrieves node wrappers archived within the specified date range using pagination.


### PR DESCRIPTION
## Summary
- expose sort-aware archive date range lookup in `NodeService`
- allow API clients to specify sort field and direction when searching nodes

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for org.saidone:alfresco-node-vault:0.0.4-SNAPSHOT: The following artifacts could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_689ad54e91dc832f9e739eeddf1ea6d1