### PR TITLE
chore: improve javadoc and swagger docs

### DIFF
--- a/src/main/java/org/saidone/controller/VaultApiController.java
+++ b/src/main/java/org/saidone/controller/VaultApiController.java
@@ -105,6 +105,7 @@ public class VaultApiController {
      * @param to   end of the archive date range (inclusive)
      * @param page page number
      * @param size page size
+     * @param dir  sort direction for archive date
      * @return paginated list of node entries
      */
     @SecurityRequirement(name = "basicAuth")
@@ -468,7 +469,7 @@ public class VaultApiController {
             })
     public ResponseEntity<?> updateKey(
             @Parameter(hidden = true) @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String auth,
-            @Parameter int keyVersion) {
+            @RequestParam(name = "keyVersion") @Parameter(name = "keyVersion", description = "Version of the encryption key to update", required = true) int keyVersion) {
 
         if (!authenticationService.isAuthorized(auth)) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();

--- a/src/main/java/org/saidone/repository/EncryptedMongoNodeRepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/EncryptedMongoNodeRepositoryImpl.java
@@ -38,6 +38,9 @@ import java.util.Optional;
  * Repository implementation that encrypts {@link NodeWrapper} data before
  * persisting it to MongoDB and decrypts it on retrieval.
  *
+ * <p>Encryption keys are supplied by {@link SecretService} and the actual
+ * cryptographic operations are delegated to {@link CryptoService}.</p>
+ *
  * <p>The bean is activated only when both
  * {@code application.service.vault.encryption.enabled} and
  * {@code application.service.vault.encryption.metadata} are set to
@@ -96,7 +99,11 @@ public class EncryptedMongoNodeRepositoryImpl extends MongoNodeRepositoryImpl {
         return result;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The resulting nodes are decrypted before being returned.</p>
+     */
     @Override
     public Page<NodeWrapper> findByArchiveDateRange(Instant from, Instant to, Pageable pageable) {
         val result = super.findByArchiveDateRange(from, to, pageable);

--- a/src/main/java/org/saidone/repository/MongoNodeRepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/MongoNodeRepositoryImpl.java
@@ -224,7 +224,7 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
      *
      * @param from lower bound of the archive date range, inclusive. {@code null} for no lower bound.
      * @param to   upper bound of the archive date range, inclusive. {@code null} for no upper bound.
-     * @return list of matching nodes
+     * @return page of matching nodes
      */
     public Page<NodeWrapper> findByArchiveDateRange(Instant from, Instant to) {
         return findByArchiveDateRange(from, to, null);
@@ -232,6 +232,12 @@ public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepos
 
     /**
      * Retrieves node wrappers archived within the specified date range using pagination.
+     *
+     * <p>When both {@code from} and {@code to} are {@code null}, this method
+     * delegates to {@link #findAll(Pageable)}.</p>
+     *
+     * <p>If the supplied {@link Pageable} does not define a sort order, results
+     * are ordered by archive date in ascending order.</p>
      *
      * @param from     lower bound of the archive date range, inclusive. {@code null} for no lower bound.
      * @param to       upper bound of the archive date range, inclusive. {@code null} for no upper bound.

--- a/src/main/java/org/saidone/service/MongoNodeService.java
+++ b/src/main/java/org/saidone/service/MongoNodeService.java
@@ -27,7 +27,6 @@ import org.saidone.model.NodeWrapper;
 import org.saidone.repository.MongoNodeRepositoryImpl;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -45,7 +44,12 @@ public class MongoNodeService extends BaseComponent implements NodeService {
     /** Repository used for persisting and retrieving node metadata. */
     private final MongoNodeRepositoryImpl mongoNodeRepository;
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply delegates to
+     * {@link MongoNodeRepositoryImpl#save(NodeWrapper)}.</p>
+     */
     @Override
     @SneakyThrows
     public void save(NodeWrapper nodeWrapper) {
@@ -95,6 +99,9 @@ public class MongoNodeService extends BaseComponent implements NodeService {
 
     /**
      * {@inheritDoc}
+     *
+     * <p>The returned iterable is backed by the underlying repository and
+     * reflects the current state of the vault.</p>
      */
     @Override
     public Iterable<NodeWrapper> findAll() {

--- a/src/main/java/org/saidone/service/NodeService.java
+++ b/src/main/java/org/saidone/service/NodeService.java
@@ -22,7 +22,6 @@ import org.saidone.exception.NodeNotFoundOnVaultException;
 import org.saidone.model.NodeWrapper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 
 import java.time.Instant;
 
@@ -30,6 +29,10 @@ import java.time.Instant;
  * Service abstraction for persisting and retrieving node metadata within the
  * vault. Implementations typically store {@link NodeWrapper} instances in a
  * backing store such as MongoDB.
+ *
+ * <p>The API is intentionally minimal and focused on CRUD-style operations.
+ * Higher level orchestration of archive and restore flows is handled by
+ * {@link org.saidone.service.VaultService}.</p>
  */
 public interface NodeService {
 


### PR DESCRIPTION
## Summary
- enrich Javadoc across repositories, services and controller
- document search sorting and key version parameter in Vault API
- clarify repository encryption behaviour and date range queries

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689adabb6a80832fa34bff5781b0354a