### PR TITLE
docs: enhance javadocs for vault API and repository

### DIFF
--- a/src/main/java/org/saidone/controller/VaultApiController.java
+++ b/src/main/java/org/saidone/controller/VaultApiController.java
@@ -100,6 +100,12 @@ public class VaultApiController {
 
     /**
      * Searches nodes archived within the specified date range with pagination support.
+     * <p>
+     * If no range is supplied the search defaults to the last 24 hours ending at
+     * {@link Instant#now()}. This mirrors the behaviour of the underlying service
+     * which looks for nodes archived during the previous day when no parameters
+     * are provided.
+     * </p>
      *
      * @param auth optional Basic authentication header
      * @param from start of the archive date range (inclusive)

--- a/src/main/java/org/saidone/repository/MongoNodeRepositoryImpl.java
+++ b/src/main/java/org/saidone/repository/MongoNodeRepositoryImpl.java
@@ -69,11 +69,20 @@ import java.util.stream.Stream;
 @ConditionalOnProperty(name = "application.service.vault.encryption.enabled", havingValue = "false", matchIfMissing = true)
 @Slf4j
 public class MongoNodeRepositoryImpl extends BaseComponent implements MongoRepository<NodeWrapper, String> {
-
+    /**
+     * Template for executing MongoDB operations. It provides low level access to
+     * the database and is used throughout this repository for persistence and
+     * queries.
+     */
     private final MongoOperations mongoOperations;
 
     /**
      * {@inheritDoc}
+     * <p>
+     * The method verifies that the MongoDB connection is available at start-up.
+     * If the connection cannot be established the application is shut down to
+     * avoid running in an inconsistent state.
+     * </p>
      */
     @PostConstruct
     @Override


### PR DESCRIPTION
## Summary
- clarify search default time range in `VaultApiController`
- document MongoDB template and startup check in `MongoNodeRepositoryImpl`

## Testing
- `mvn -q -e -ntp test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c31d93234832fbe3ff67865d4b2a3