### PR TITLE
Add Swagger annotations for integrity sweep endpoints

### DIFF
--- a/src/main/java/org/saidone/controller/VaultApiController.java
+++ b/src/main/java/org/saidone/controller/VaultApiController.java
@@ -517,6 +517,20 @@ public class VaultApiController extends BaseComponent {
      */
     @SecurityRequirement(name = "basicAuth")
     @GetMapping("/integrity-sweeps")
+    @Operation(
+            summary = "List integrity sweep runs",
+            description = "Returns integrity sweep runs ordered by start time (most recent first).",
+            parameters = {
+                    @Parameter(name = "page", description = "Page number", in = ParameterIn.QUERY),
+                    @Parameter(name = "size", description = "Page size", in = ParameterIn.QUERY)
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Integrity sweep runs retrieved",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = IntegritySweepRun.class))),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content),
+                    @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content)
+            })
     public ResponseEntity<Page<IntegritySweepRun>> getIntegritySweepRuns(
             @Parameter(hidden = true) @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String auth,
             @RequestParam(required = false, defaultValue = "0") int page,
@@ -538,6 +552,15 @@ public class VaultApiController extends BaseComponent {
      */
     @SecurityRequirement(name = "basicAuth")
     @PostMapping("/integrity-sweeps/run")
+    @Operation(
+            summary = "Run integrity sweep",
+            description = "Starts an integrity sweep asynchronously and returns immediately.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Integrity sweep required",
+                            content = @Content(mediaType = "text/plain")),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content),
+                    @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content)
+            })
     public ResponseEntity<String> runIntegritySweep(
             @Parameter(hidden = true) @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String auth) {
 


### PR DESCRIPTION
### Motivation
- Add OpenAPI/Swagger annotations to the integrity sweep endpoints so they are documented consistently with the other Vault API methods.

### Description
- Added `@Operation` annotations to `getIntegritySweepRuns` and `runIntegritySweep`, documenting `summary`, `description`, query parameters (`page`, `size`), standard responses (`200`, `401`, `500`), and the response schema for the GET (`IntegritySweepRun.class`), and noted the asynchronous behavior for the POST.

### Testing
- Executed `mvn -q -DskipTests compile`, which failed due to remote Alfresco dependency resolution returning `403 Forbidden`, so no automated tests could be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7a3ba408832fa6c250e617755b24)