### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.6</version>
         <relativePath/>
     </parent>
     <groupId>org.saidone</groupId>
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
-            <version>3.0.2</version>
+            <version>3.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -101,27 +101,27 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.21.0</version>
+            <version>2.22.0</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-            <version>1.83</version>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
-            <version>2.42.18</version>
+            <version>2.42.41</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sdk-core</artifactId>
-            <version>2.42.18</version>
+            <version>2.42.41</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3-transfer-manager</artifactId>
-            <version>2.42.18</version>
+            <version>2.42.41</version>
         </dependency>
         <dependency>
             <groupId>org.web3j</groupId>


### PR DESCRIPTION
- Updated Spring Boot parent version to 4.0.6.
- Updated Springdoc-OpenAPI-Starter-Webflux-UI version to 3.0.3.
- Updated Commons-IO version to 2.22.0.
- Updated BouncyCastle version to 1.84.
- Updated AWS SDK S3 version to 2.42.41.
- Updated AWS SDK SDK-Core version to 2.42.41.
- Updated AWS SDK S3-Transfer-Manager version to 2.42.41.
- Updated Web3j version to 1.10.0.